### PR TITLE
fix: added missing re-raise

### DIFF
--- a/kinesis/base.py
+++ b/kinesis/base.py
@@ -69,6 +69,7 @@ class Base:
                 raise exceptions.StreamDoesNotExist(
                     "Stream '{}' does not exist".format(self.stream_name)
                 ) from None
+            raise
 
     async def start(self, skip_describe_stream=False):
 


### PR DESCRIPTION
Without it, this `except` is silently consuming AWS errors (other than "stream not found")

---

There might be other places with the same problem.. Feel free reject this PR and fix it in any way you see fit.

BEFORE
```
Traceback (most recent call last):
  File "roles/kinesis_to_influx/files/bin/kinesis_to_influx.py", line 449, in <module>
    asyncio.run(main())
  File "/usr/lib64/python3.7/asyncio/runners.py", line 43, in run
    return loop.run_until_complete(main)
  File "/usr/lib64/python3.7/asyncio/base_events.py", line 587, in run_until_complete
    return future.result()
  File "roles/kinesis_to_influx/files/bin/kinesis_to_influx.py", line 444, in main
    coroutine,
  File "roles/kinesis_to_influx/files/bin/kinesis_to_influx.py", line 399, in kinesis_consumer
    async for cf_log_line in kinesis_stream:
  File "/home/zarnovic/.virtualenvs/kinesis/lib64/python3.7/site-packages/kinesis/consumer.py", line 362, in __anext__
    await self.start_consumer()
  File "/home/zarnovic/.virtualenvs/kinesis/lib64/python3.7/site-packages/kinesis/consumer.py", line 347, in start_consumer
    await self.start()
  File "/home/zarnovic/.virtualenvs/kinesis/lib64/python3.7/site-packages/kinesis/base.py", line 89, in start
    stream_status = stream_info["StreamStatus"]
TypeError: 'NoneType' object is not subscriptable
```

AFTER:
```
Traceback (most recent call last):
  File "roles/kinesis_to_influx/files/bin/kinesis_to_influx.py", line 449, in <module>
    asyncio.run(main())
  File "/usr/lib64/python3.7/asyncio/runners.py", line 43, in run
    return loop.run_until_complete(main)
  File "/usr/lib64/python3.7/asyncio/base_events.py", line 587, in run_until_complete
    return future.result()
  File "roles/kinesis_to_influx/files/bin/kinesis_to_influx.py", line 444, in main
    coroutine,
  File "roles/kinesis_to_influx/files/bin/kinesis_to_influx.py", line 399, in kinesis_consumer
    async for cf_log_line in kinesis_stream:
  File "/home/zarnovic/.virtualenvs/kinesis/lib64/python3.7/site-packages/kinesis/consumer.py", line 362, in __anext__
    await self.start_consumer()
  File "/home/zarnovic/.virtualenvs/kinesis/lib64/python3.7/site-packages/kinesis/consumer.py", line 347, in start_consumer
    await self.start()
  File "/home/zarnovic/.virtualenvs/kinesis/lib64/python3.7/site-packages/kinesis/base.py", line 89, in start
    stream_info = await self.get_stream_description()
  File "/home/zarnovic/.virtualenvs/kinesis/lib64/python3.7/site-packages/kinesis/base.py", line 63, in get_stream_description
    return (await self.client.describe_stream(StreamName=self.stream_name))[
  File "/home/zarnovic/.virtualenvs/kinesis/lib64/python3.7/site-packages/aiobotocore/client.py", line 134, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (ExpiredTokenException) when calling the DescribeStream operation: The security token included in the request is expired
```