### PR TITLE
refactored flush method in producer and added connection error retry and backoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ Options:
 | max_queue_size | 10000 | put() method will block when queue is at max |
 | after_flush_fun | None | async function to call after doing a flush (err put_records()) call |
 | processor | JsonProcessor() | Record aggregator/serializer. Default is JSON without aggregation. Note this is highly inefficient as each record can be up to 1Mib |
+| retry_limit | None | How many connection attempts should be made before raising a exception |
+| expo_backoff | None | Exponential Backoff when connection attempt fails |
+| expo_backoff_limit | 120 | Max amount of seconds Exponential Backoff can grow |
+| create_stream | False | Creates a Kinesis Stream based on the `stream_name` keyword argument. Note if stream already existing it will ignore |
+| create_stream_shards | 1 | Sets the amount of shard you want for your new stream. Note if stream already existing it will ignore  |
 
 * Throughput exceeded. The docs (for Java/KPL see: https://docs.aws.amazon.com/streams/latest/dev/kinesis-producer-adv-retries-rate-limiting.html) state:
 
@@ -90,6 +95,11 @@ Options:
 | shard_fetch_rate | 1 | No of fetches per second (max = 5). 1 is recommended as allows having multiple consumers without hitting the max limit. |
 | checkpointer | MemoryCheckPointer() | Checkpointer to use |
 | processor | JsonProcessor() |  Record aggregator/serializer. Must Match processor used by Producer() |
+| retry_limit | None | How many connection attempts should be made before raising a exception |
+| expo_backoff | None | Exponential Backoff when connection attempt fails |
+| expo_backoff_limit | 120 | Max amount of seconds Exponential Backoff can grow |
+| create_stream | False | Creates a Kinesis Stream based on the `stream_name` keyword argument. Note if stream already existing it will ignore |
+| create_stream_shards | 1 | Sets the amount of shard you want for your new stream. Note if stream already existing it will ignore  |
 
 
 ## Checkpointers

--- a/kinesis/base.py
+++ b/kinesis/base.py
@@ -170,6 +170,7 @@ class Base:
                 log.warning(f"Connection Reestablished After {conn_attempts} and Sleeping for {backoff_delay}")
                 break
             except Exception as e:
+                log.warning(e)
                 conn_attempts += 1
                 if isinstance(self.retry_limit, int):
                     if conn_attempts >= (self.retry_limit + 1):

--- a/kinesis/consumer.py
+++ b/kinesis/consumer.py
@@ -46,6 +46,8 @@ class Consumer(Base):
         expo_backoff=None,
         expo_backoff_limit=120,
         skip_describe_stream=False,
+        create_stream=False,
+        create_stream_shards=1
     ):
 
         super(Consumer, self).__init__(
@@ -54,6 +56,8 @@ class Consumer(Base):
             expo_backoff=expo_backoff,
             expo_backoff_limit=expo_backoff_limit,
             skip_describe_stream=skip_describe_stream,
+            create_stream=create_stream,
+            create_stream_shards=create_stream_shards
         )
 
         self.queue = asyncio.Queue(maxsize=max_queue_size)

--- a/kinesis/consumer.py
+++ b/kinesis/consumer.py
@@ -85,7 +85,7 @@ class Consumer(Base):
 
     async def close(self):
         log.debug("Closing Connection..")
-        if not self.stream_status == "RECONNECT":
+        if not self.stream_status == self.RECONNECT:
 
             await self.flush()
 
@@ -361,7 +361,7 @@ class Consumer(Base):
 
         # Start task to fetch periodically
 
-        self.fetch_task = asyncio.create_task(self._fetch(), name='Fetch Task')
+        self.fetch_task = asyncio.create_task(self._fetch())
 
         # Wait a while until we have some results
         for i in range(0, wait_iterations):

--- a/kinesis/consumer.py
+++ b/kinesis/consumer.py
@@ -289,7 +289,6 @@ class Consumer(Base):
                     return result
 
                 except ClientConnectionError as e:
-                    self.stream_status = "RECONNECT"
                     await self.get_conn()
                 except TimeoutError as e:
                     log.warning("Timeout {}. sleeping..".format(e))
@@ -316,6 +315,10 @@ class Consumer(Base):
                             shard_id=shard["ShardId"],
                             last_sequence_number=shard.get("LastSequenceNumber"),
                         )
+
+                    elif code == "InternalFailure":
+                        log.warning('Received InternalFailure from Kinesis, rebuilding connection.. ')
+                        await self.get_conn()
 
                     else:
                         log.warning("ClientError {}. sleeping..".format(code))

--- a/kinesis/producer.py
+++ b/kinesis/producer.py
@@ -345,7 +345,7 @@ class Producer(Base):
                         items = await self.get_batch()
 
                     else:
-                        log.warning(f'Unfound error code {err.response["Error"]["Code"]}')
+                        log.warning(f'Unknown ValidationException error code {err.response["Error"]["Code"]}')
                         log.exception(err)
                         await self.get_conn()
                         #raise err
@@ -354,7 +354,10 @@ class Producer(Base):
                         "Stream '{}' does not exist".format(self.stream_name)
                     ) from None
                 else:
-                    raise err
+                    log.warning(f'Unknown Client error code {err.response["Error"]["Code"]}')
+                    log.exception(err)
+                    await self.get_conn()
+                    # raise err
             except ClientConnectionError as err:
                 await self.get_conn()
 

--- a/kinesis/producer.py
+++ b/kinesis/producer.py
@@ -345,7 +345,10 @@ class Producer(Base):
                         items = await self.get_batch()
 
                     else:
-                        raise err
+                        log.warning(f'Unfound error code {err.response["Error"]["Code"]}')
+                        log.exception(err)
+                        await self.get_conn()
+                        #raise err
                 elif code == "ResourceNotFoundException":
                     raise exceptions.StreamDoesNotExist(
                         "Stream '{}' does not exist".format(self.stream_name)

--- a/kinesis/producer.py
+++ b/kinesis/producer.py
@@ -74,7 +74,7 @@ class Producer(Base):
             )
         self.set_put_rate_throttle()
 
-        self.flush_task = asyncio.create_task(self._flush(), name='Flush Task')
+        self.flush_task = asyncio.create_task(self._flush())
         self.is_flushing = False
         self.after_flush_fun = after_flush_fun
 
@@ -109,7 +109,7 @@ class Producer(Base):
         if self.flush_task.done():
             raise self.flush_task.exception()
 
-        if not self.stream_status == "ACTIVE":
+        if not self.stream_status == self.ACTIVE:
             await self.get_conn()
 
         elif self.queue.qsize() >= self.batch_size:
@@ -120,7 +120,7 @@ class Producer(Base):
 
     async def close(self):
         log.debug("Closing Connection..")
-        if not self.stream_status == "RECONNECT":
+        if not self.stream_status == self.RECONNECT:
             # Cancel Flush Task
             self.flush_task.cancel()
             # final flush (probably not required but no harm)
@@ -130,7 +130,7 @@ class Producer(Base):
 
     async def _flush(self):
         while True:
-            if self.stream_status == "ACTIVE":
+            if self.stream_status == self.ACTIVE:
                 if not self.is_flushing:
                     await self.flush()
             await asyncio.sleep(self.buffer_time)

--- a/kinesis/producer.py
+++ b/kinesis/producer.py
@@ -283,7 +283,7 @@ class Producer(Base):
 
     async def _push_kinesis(self, items):
 
-        log.info(
+        log.debug(
             "doing flush with {} record ({} items) @ {} kb".format(
                 len(items), self.flush_total_records, self.flush_total_size
             )

--- a/tests.py
+++ b/tests.py
@@ -865,14 +865,13 @@ class AWSKinesisTests(BaseKinesisTests):
                 await producer.create_stream(shards=shards)
                 await producer.start()
 
-        asyncio.gather(
-            *[
+        asyncio.run(
                 create(
                     stream_name=cls.STREAM_NAME_SINGLE_SHARD, shards=1
-                ),
-                #   create(loop=setup_loop, stream_name=cls.STREAM_NAME_MULTI_SHARD, shards=3)
-            ]
+                )
         )
+        #   create(loop=setup_loop, stream_name=cls.STREAM_NAME_MULTI_SHARD, shards=3)
+
 
 
     @classmethod


### PR DESCRIPTION

Broke up the flush method in the producer to use three different methods ex. `get_batch, _push_kinesis, process_result`

Added retry limit when there is a connection error so it hard fails (usefully for containers) and added a option for exponential_backoff for connection error retries. `get_connection_exponential_backoff`

fixed a test was made to create the kinesis stream. Last change gave me a false positive since the stream was already up in aws. 

Test were ran with `TESTING_USE_AWS_KINESIS=1` with all 34 passing.

Unit test have not been create for this yet, so it's not ready to merge. Just looking for some feedback to make sure I didn't miss something or if I need to break this up into separate pull requests.
