### PR TITLE
feat: add KPL Aggregated Record aggregation

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ Refer https://aws.amazon.com/blogs/big-data/implementing-efficient-and-reliable-
 | JsonLineProcessor | NewlineAggregator | JsonSerializer | Multiple JSON record separated by new line char |
 | JsonListProcessor | ListAggregator | JsonSerializer | Multiple JSON record returned by list |
 | MsgpackProcessor | NetstringAggregator | MsgpackSerializer | Multiple Msgpack record framed with Netstring Protocol (https://en.wikipedia.org/wiki/Netstring) |
+| KPLJsonProcessor | KPLAggregator | JsonSerializer | Multiple JSON record in a KPL Aggregated Record (https://github.com/awslabs/amazon-kinesis-producer/blob/master/aggregation-format.md) |
+| KPLStringProcessor | KPLAggregator | StringSerializer | Multiple String record in a KPL Aggregated Record (https://github.com/awslabs/amazon-kinesis-producer/blob/master/aggregation-format.md) | 
 
 Note you can define your own processor easily as it's simply a class inheriting the Aggregator + Serializer.
 

--- a/kinesis/aggregators.py
+++ b/kinesis/aggregators.py
@@ -4,6 +4,13 @@ from collections import namedtuple
 from .exceptions import ValidationError
 from .exceptions import ExceededPutLimit
 
+try:
+    import aws_kinesis_agg
+    import aws_kinesis_agg.aggregator
+    import aws_kinesis_agg.kpl_pb2
+except ModuleNotFoundError:
+    pass
+
 log = logging.getLogger(__name__)
 
 OutputItem = namedtuple("OutputItem", ["size", "n", "data"])
@@ -172,3 +179,44 @@ class NetstringAggregator(Aggregator):
             i += header_offset + size + 2
             if i == length:
                 break
+
+
+class KPLAggregator(Aggregator):
+    """
+    KPL Aggregated Record Aggregation
+    See: https://github.com/awslabs/kinesis-aggregation/tree/master/python
+    """
+
+    def __init__(self, max_size=None):
+        if max_size is not None:
+            # Ideally, aws_kinesis_agg will make this configurable at some point..
+            log.warning("KPL Aggregation does not support max_size. Using aws_kinesis_agg.MAX_BYTES_PER_RECORD of {}").format(aws_kinesis_agg.MAX_BYTES_PER_RECORD)
+        self.agg = aws_kinesis_agg.aggregator.RecordAggregator()
+
+    def has_items(self):
+        return self.agg.get_num_user_records() > 0
+
+    def add_item(self, item):
+        output = self.serialize(item)
+        record = self.agg.add_user_record('a', output)
+        self.size = self.agg.get_num_user_records()
+        if record:
+            size = record.get_size_bytes()
+            n = record.get_num_user_records()
+            partition_key, explicit_hash_key, data = record.get_contents()
+            yield OutputItem(size=size, n=n, data=data)
+
+    def get_items(self):
+        record = self.agg.clear_and_get()
+        if record:
+            size = record.get_size_bytes()
+            n = record.get_num_user_records()
+            partition_key, explicit_hash_key, data = record.get_contents()
+            yield OutputItem(size=size, n=n, data=data)
+
+    def parse(self, data):
+        message_data = data[len(aws_kinesis_agg.MAGIC):-aws_kinesis_agg.DIGEST_SIZE]
+        ar = aws_kinesis_agg.kpl_pb2.AggregatedRecord()
+        ar.ParseFromString(message_data)
+        for record in ar.records:
+            yield self.deserialize(record.data)

--- a/kinesis/aggregators.py
+++ b/kinesis/aggregators.py
@@ -189,8 +189,8 @@ class KPLAggregator(Aggregator):
 
     def __init__(self, max_size=None):
         if max_size is not None:
-            # Ideally, aws_kinesis_agg will make this configurable at some point..
-            log.warning("KPL Aggregation does not support max_size. Using aws_kinesis_agg.MAX_BYTES_PER_RECORD of {}").format(aws_kinesis_agg.MAX_BYTES_PER_RECORD)
+            # Ideally, aws_kinesis_agg will make this configurable. See https://github.com/awslabs/kinesis-aggregation/pull/129
+            raise ValidationError("KPL Aggregation does not support max_size.")
         self.agg = aws_kinesis_agg.aggregator.RecordAggregator()
 
     def has_items(self):

--- a/kinesis/processors.py
+++ b/kinesis/processors.py
@@ -1,4 +1,4 @@
-from .aggregators import NewlineAggregator, SimpleAggregator, NetstringAggregator, ListAggregator
+from .aggregators import NewlineAggregator, SimpleAggregator, NetstringAggregator, ListAggregator, KPLAggregator
 from .serializers import StringSerializer, JsonSerializer, MsgpackSerializer
 
 
@@ -23,4 +23,12 @@ class JsonListProcessor(Processor, ListAggregator, JsonSerializer):
 
 
 class MsgpackProcessor(Processor, NetstringAggregator, MsgpackSerializer):
+    pass
+
+
+class KPLJsonProcessor(Processor, KPLAggregator, JsonSerializer):
+    pass
+
+
+class KPLStringProcessor(Processor, KPLAggregator, StringSerializer):
     pass

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
         "asyncio-throttle>=0.1.1",
     ],
     extras_require={
+        "kpl": ["aws-kinesis-agg"],
         "redis": ["aredis>=1.1.8"],
         "msgpack": ["msgpack>=0.6.1"]
     }

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,6 @@
 -r requirements.txt
 
+aws-kinesis-agg==1.1.4
 coloredlogs==10.0
 nose==1.3.7
 pinocchio==0.4.2

--- a/tests.py
+++ b/tests.py
@@ -177,6 +177,11 @@ class ProcessorAndAggregatorTests(TestCase, BaseTests):
 
         self.assertListEqual(list(processor.parse(output[0].data)), ["123", "test"])
 
+    def test_kpl_aggregator_max_size(self):
+
+        with self.assertRaises(exceptions.ValidationError):
+            KPLAggregator(max_size=2000)
+
     def test_string_processor(self):
 
         processor = StringProcessor()

--- a/tests.py
+++ b/tests.py
@@ -15,6 +15,7 @@ from kinesis.processors import (
 )
 from kinesis.aggregators import (
     Aggregator,
+    KPLAggregator,
     SimpleAggregator,
     NewlineAggregator,
     ListAggregator,
@@ -153,6 +154,26 @@ class ProcessorAndAggregatorTests(TestCase, BaseTests):
         self.assertEqual(output[0].size, 13)
         self.assertEqual(output[0].n, 2)
         self.assertEqual(output[0].data, b"3:123,4:test,")
+
+        self.assertListEqual(list(processor.parse(output[0].data)), ["123", "test"])
+
+    def test_kpl_aggregator(self):
+        class KPLTestProcessor(KPLAggregator, StringSerializer):
+            pass
+
+        processor = KPLTestProcessor()
+
+        # Expect nothing as batching
+        self.assertEqual([], list(processor.add_item(123)))
+        self.assertEqual([], list(processor.add_item("test")))
+
+        self.assertTrue(processor.has_items())
+
+        output = list(processor.get_items())
+
+        self.assertEqual(len(output), 1)
+
+        self.assertEqual(output[0].n, 2)
 
         self.assertListEqual(list(processor.parse(output[0].data)), ["123", "test"])
 


### PR DESCRIPTION
Hey @hampsterx ! I appreciate this library though I've only just started to look at it. I like the interfaces you've set up though, and I'd like to add one:

KPL Record Aggregation is what the kinesis producer library uses, and awslabs has a python impl of the aggregation method. A major benefit of using this is potential compatibility with tools that already understand this aggregation method. Kinesis Firehose for example natively understands this aggregation and will write the deaggregated records to s3 without having to configure a deaggregation transform in the firehose configuration.

Heads up, I just put this together and haven't actually tried using it. We have been using the awslabs aws_kinesis_agg library for a while, but are only recently looking at asyncio and found your lib when looking for an async kinesis client. I *think* this should work and will try it at some point.

Also, if you're amenable, I can try to contribute a protobuf serializer in a separate change?

And finally, have you thought about adding compression as a feature? For the json strings in particular, I think it would be really nice.