### PR TITLE
consumer skip trying to checkpoint binary items

### DIFF
--- a/kinesis/consumer.py
+++ b/kinesis/consumer.py
@@ -387,10 +387,7 @@ class Consumer(Base):
             try:
                 item = self.queue.get_nowait()
 
-                if isinstance(item, (bytes, bytearray)):
-                    return item
-
-                if item and "__CHECKPOINT__" in item:
+                if item and isinstance(item, dict) and "__CHECKPOINT__" in item:
                     if self.checkpointer:
                         await self.checkpointer.checkpoint(
                             item["__CHECKPOINT__"]["ShardId"],

--- a/kinesis/consumer.py
+++ b/kinesis/consumer.py
@@ -387,15 +387,16 @@ class Consumer(Base):
             try:
                 item = self.queue.get_nowait()
 
+                if isinstance(item, (bytes, bytearray)):
+                    return item
+
                 if item and "__CHECKPOINT__" in item:
                     if self.checkpointer:
                         await self.checkpointer.checkpoint(
                             item["__CHECKPOINT__"]["ShardId"],
                             item["__CHECKPOINT__"]["SequenceNumber"],
                         )
-                        continue
-                    else:
-                        continue
+                    continue
 
                 return item
 


### PR DESCRIPTION
#22 

```
kinesis.base WARNING Connection Successfully Initialized
kinesis.aggregators DEBUG Adding item to queue with size of 0 kb
kinesis.aggregators DEBUG Adding item to queue with size of 0 kb
kinesis.aggregators DEBUG Yielding (final) item to queue with 2 individual records with size of 0 kb
kinesis.producer DEBUG flush queue=1 overflow=0
kinesis.producer DEBUG doing flush with 1 record (2 items) @ 1 kb
kinesis.producer INFO flush complete with 1 record (2 items) @ 1 kb
kinesis.base INFO creating client with http://localhost:4567
kinesis.base DEBUG Checking stream 'test_f93e2ea5' is active
kinesis.base WARNING Connection Successfully Initialized
kinesis.consumer DEBUG Marking shard in use shardId-000000000000 by checkpointer[test/221751] @ None
kinesis.consumer DEBUG getting shard iterator for shardId-000000000000 @ TRIM_HORIZON
kinesis.consumer DEBUG Shard count now at 1
kinesis.consumer DEBUG Shard shardId-000000000000 got 1 records
kinesis.consumer DEBUG Shard shardId-000000000000 added 2 items from 1 records. Consumer is 0m behind
kinesis.consumer DEBUG start_consumer completed.. queue size=3
kinesis.checkpointers DEBUG test/221751 checkpointed on shardId-000000000000 @ seq
kinesis.checkpointers DEBUG test/221751 checkpointed on shardId-000000000000 @ seq
kinesis.checkpointers DEBUG test/221751 checkpointed on shardId-000000000000 @ 49614775414386148913498287715799643957917344686715961346
kinesis.consumer DEBUG Queue empty..
kinesis.consumer DEBUG Shard shardId-000000000000 caught up, sleeping 2s
kinesis.consumer DEBUG Queue empty..
kinesis.consumer DEBUG Shard shardId-000000000000 caught up, sleeping 2s
kinesis.consumer DEBUG Closing Connection..
kinesis.checkpointers INFO test/221751 stopping..
kinesis.checkpointers INFO test/221751 deallocated on shardId-000000000000@{'sequence': '49614775414386148913498287715799643957917344686715961346', 'active': True}
kinesis.checkpointers INFO test/221751 stopping..
kinesis.checkpointers INFO test/221751 deallocated on shardId-000000000000@{'sequence': '49614775414386148913498287715799643957917344686715961346', 'active': False}
kinesis.producer DEBUG Closing Connection..
- producer and consumer consume with bytes
```

Seems good~
