### PR TITLE
Confirm NextShardIterator key exist to fetch to consumer on same shard

### DIFF
--- a/kinesis/consumer.py
+++ b/kinesis/consumer.py
@@ -263,8 +263,9 @@ class Consumer(Base):
                         )
                         await asyncio.sleep(self.sleep_time_no_records)
 
-                    if not result["NextShardIterator"]:
-                        raise NotImplementedError("Shard is closed?")
+                    if not result.get("NextShardIterator"):
+                        shard["fetch"] = None
+                        continue
 
                     shard["ShardIterator"] = result["NextShardIterator"]
 

--- a/kinesis/consumer.py
+++ b/kinesis/consumer.py
@@ -263,7 +263,7 @@ class Consumer(Base):
                         )
                         await asyncio.sleep(self.sleep_time_no_records)
 
-                    if not result.get("NextShardIterator"):
+                    if not result.get("NextShardIterator") or result.get("NextShardIterator") == 'null':
                         shard["fetch"] = None
                         continue
 


### PR DESCRIPTION
Hey Hampsterx,

So I was added shards to my kinesis stream and from the discussion I had with AWS engineer is those old shards would still be active for at least during the data retention period of your stream. However in the results from the old shards, they do not contain the `NextShardIterator` key in the results, even though it's mention it will be null in their docs.

https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/kinesis.html#Kinesis.Client.get_records

This basically makes the consumer move to the next shard if the key `NextShardIterator` is not found or is string `null` in results after returning output.