### PR TITLE
reshard test

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -941,6 +941,96 @@ class KinesisTests(BaseKinesisTests):
                     self.assertIsNotNone(item)
 
 
+class KinesisReshardTests(BaseKinesisTests):
+    """
+    Kinesalite Reshard Tests
+    @requires https://github.com/mhart/kinesalite/pull/103
+    ./cli.js --shardLimit 100
+    """
+
+    @staticmethod
+    async def describe_stream(client, stream_name):
+
+        result = await client.describe_stream(StreamName=stream_name)
+
+        log.info(f"Stream {result['StreamDescription']['StreamStatus']}")
+
+        for shard in result['StreamDescription']['Shards']:
+            start = shard['SequenceNumberRange']['StartingSequenceNumber']
+            end = shard['SequenceNumberRange'].get('EndingSequenceNumber', '')
+
+            log.info(f"Shard {shard['ShardId']} start={start} end={end}")
+
+    async def test_resharding(self):
+
+        stream_name = "test_{}".format(str(uuid.uuid4())[0:8])
+
+        # Create stream with 2x shards. Add some records
+
+        async with Producer(
+            stream_name=stream_name,
+            endpoint_url=ENDPOINT_URL,
+            create_stream=stream_name,
+            create_stream_shards=2
+        ) as producer:
+
+            for i in range(0, 50):
+                await producer.put("test.{}".format(i))
+
+            await producer.flush()
+
+            results = []
+
+            checkpointer = RedisCheckPointer(
+                name="test-{}".format(str(uuid.uuid4())[0:8]), heartbeat_frequency=3
+            )
+
+            async with Consumer(
+                    stream_name=stream_name,
+                    endpoint_url=ENDPOINT_URL,
+                    checkpointer=checkpointer,
+                    record_limit=5,
+                    # Limit the queue so there records will remain in the shards
+                    max_queue_size=5
+            ) as consumer:
+
+                for i in range(0, 3):
+                    async for item in consumer:
+                        results.append(item)
+                    await asyncio.sleep(0.5)
+
+                log.info(f"Consumed {len(results)} records")
+
+                # Start reshard operation
+                await producer.client.update_shard_count(
+                    StreamName=stream_name,
+                    TargetShardCount=4,
+                    ScalingType='UNIFORM_SCALING'
+                )
+
+                await self.describe_stream(client=producer.client, stream_name=stream_name)
+
+                await asyncio.sleep(1)
+
+                await self.describe_stream(client=producer.client, stream_name=stream_name)
+
+                # Now add some more records
+
+                for i in range(50, 100):
+                    await producer.put("test.{}".format(i))
+
+                await producer.flush()
+
+                for i in range(0, 10):
+                    async for item in consumer:
+                        results.append(item)
+                    await asyncio.sleep(0.5)
+
+                log.info(f"Consumed {len(results)} records")
+
+                assert len(results) == 100
+
+
 class AWSKinesisTests(BaseKinesisTests):
     """
     AWS Kinesis Tests


### PR DESCRIPTION

```
kinesis.consumer DEBUG Shard shardId-000000000001 got 5 records
kinesis.checkpointers DEBUG Heartbeating shardId-000000000000@49615604846537535747729525809208528210816652204025315330
kinesis.checkpointers DEBUG Heartbeating shardId-000000000001@49615604846559836492928056432312587228681247061115404306
tests INFO Consumed 15 records
tests INFO Stream UPDATING
tests INFO Shard shardId-000000000000 start=49615604846537535747729525809166215807130139976752168962 end=
tests INFO Shard shardId-000000000001 start=49615604846559836492928056432307751525402788338258149394 end=
kinesis.checkpointers DEBUG Heartbeating shardId-000000000000@49615604846537535747729525809208528210816652204025315330
kinesis.checkpointers DEBUG Heartbeating shardId-000000000001@49615604846559836492928056432312587228681247061115404306
tests INFO Stream ACTIVE
tests INFO Shard shardId-000000000000 start=49615604846537535747729525809166215807130139976752168962 end=49615604846548686120328791120735774740446850284244697090
tests INFO Shard shardId-000000000001 start=49615604846559836492928056432307751525402788338258149394 end=49615604846570986865527321743877310458719498645750677522
tests INFO Shard shardId-000000000068 start=49615604849748843056317935541547359238391504652088639490 end=
tests INFO Shard shardId-000000000069 start=49615604849771143801516466164688894956664153013594619922 end=
tests INFO Shard shardId-000000000070 start=49615604849793444546714996787830430674936801375100600354 end=
tests INFO Shard shardId-000000000071 start=49615604849815745291913527410971966393209449736606580786 end=
kinesis.producer DEBUG flush queue=50 overflow=0
kinesis.producer DEBUG doing flush with 50 record (50 items) @ 50 kb
kinesis.producer INFO flush complete with 50 record (50 items) @ 50 kb
..
Heartbeating shardId-000000000001@49615604846559836492928056432336765745073539644609527826
kinesis.consumer ERROR 'NextShardIterator'
Traceback (most recent call last):
  File "/home/tim/Workspace/async-kinesis/kinesis/consumer.py", line 121, in _fetch
    await self.fetch()
  File "/home/tim/Workspace/async-kinesis/kinesis/consumer.py", line 266, in fetch
    if not result["NextShardIterator"]:
KeyError: 'NextShardIterator'
...
kinesis.consumer DEBUG Shard shardId-000000000000 caught up, sleeping 2s
kinesis.checkpointers DEBUG Heartbeating shardId-000000000000@49615604846537535747729525809225453172291257012471201794
kinesis.checkpointers DEBUG Heartbeating shardId-000000000001@49615604846559836492928056432336765745073539644609527826
tests INFO Expected 100 records. Consumed 44 records
kinesis.consumer DEBUG Closing Connection..
kinesis.checkpointers DEBUG Cancelling heartbeat task..
kinesis.checkpointers INFO test-5390a0c5/151976 stopping..
kinesis.checkpointers INFO test-5390a0c5/151976 deallocated on shardId-000000000000@49615604846537535747729525809225453172291257012471201794
kinesis.checkpointers INFO test-5390a0c5/151976 deallocated on shardId-000000000001@49615604846559836492928056432336765745073539644609527826
kinesis.producer DEBUG Closing Connection.. (stream status:ACTIVE)

```
#26  @jmcgrath207 might merge this and tests can fail forever until we get this behaviour in, no rush :)


 
