### PR TITLE
Allow graceful shutdown when task is cancelled

### DIFF
--- a/kinesis/producer.py
+++ b/kinesis/producer.py
@@ -337,7 +337,8 @@ class Producer(Base):
                     # raise err
             except ClientConnectionError as err:
                 await self.get_conn()
-
+            except asyncio.CancelledError:
+                return
             except Exception as e:
                 log.exception(e)
                 log.critical("Unknown Exception Caught")


### PR DESCRIPTION
Current exception handling logic is too broad and it tries to reconnect endlessly in case of unknown exceptions.
In my service I'm using the logic that is cancelling all asyncio tasks on termination signal in order to shutdown gracefully. Unfortunately it conflicts with the exception handling of the producer.

In order to allow graceful shutdown of the producer I've added `asyncio.CancelledError` exception handling that will exit endless loop and allow process to shutdown.