### PR TITLE
add test for stream arn

### DIFF
--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -310,7 +310,10 @@ class TestConsumer:
             ("test-stream", False),
             ("my_stream", False),
             ("stream-123", False),
-            ("arnot:aws:kinesis:us-east-1:123456789012:stream/test", False),  # Invalid prefix
+            (
+                "arnot:aws:kinesis:us-east-1:123456789012:stream/test",
+                False,
+            ),  # Invalid prefix
             ("arn-test-stream", False),  # Starts with arn but not a valid ARN
         ]
 

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -282,20 +282,53 @@ class TestConsumer:
 
     @pytest.mark.asyncio
     async def test_consumer_stream_arn_support(self, endpoint_url):
-        """Test consumer with stream ARN (if supported)."""
-        # This would test the new ARN functionality from the recent PR
-        stream_arn = "arn:aws:kinesis:us-east-1:123456789012:stream/test-stream"
+        """Test consumer with stream ARN (PR #39)."""
+        # Create a mock ARN
+        stream_arn = "arn:aws:kinesis:us-east-1:123456789012:stream/test-consumer-arn"
 
-        # This might fail if ARN support isn't fully implemented yet
-        try:
-            async with Consumer(
-                stream_name=stream_arn,
+        consumer = Consumer(
+            stream_name=stream_arn,
+            endpoint_url=endpoint_url,
+        )
+
+        # Verify that the address property returns StreamARN
+        address = consumer.address
+        assert "StreamARN" in address
+        assert address["StreamARN"] == stream_arn
+        assert "StreamName" not in address
+        assert consumer.stream_name == stream_arn
+
+    @pytest.mark.asyncio
+    async def test_consumer_arn_format_validation(self, endpoint_url):
+        """Test consumer correctly handles various ARN formats (PR #39)."""
+        test_cases = [
+            # (stream_name, should_be_arn)
+            ("arn:aws:kinesis:us-east-1:123456789012:stream/test", True),
+            ("arn:aws:kinesis:eu-west-1:999999999999:stream/my-stream", True),
+            ("arn:aws-cn:kinesis:cn-north-1:123456789012:stream/test", True),
+            ("arn:aws-us-gov:kinesis:us-gov-west-1:123456789012:stream/test", True),
+            ("test-stream", False),
+            ("my_stream", False),
+            ("stream-123", False),
+            ("arnot:aws:kinesis:us-east-1:123456789012:stream/test", False),  # Invalid prefix
+            ("arn-test-stream", False),  # Starts with arn but not a valid ARN
+        ]
+
+        for stream_name, should_be_arn in test_cases:
+            consumer = Consumer(
+                stream_name=stream_name,
                 endpoint_url=endpoint_url,
-            ) as consumer:
-                assert consumer.stream_name == stream_arn
-        except Exception:
-            # ARN support might not be fully implemented yet
-            pytest.skip("ARN support not fully implemented")
+            )
+            address = consumer.address
+
+            if should_be_arn:
+                assert "StreamARN" in address
+                assert address["StreamARN"] == stream_name
+                assert "StreamName" not in address
+            else:
+                assert "StreamName" in address
+                assert address["StreamName"] == stream_name
+                assert "StreamARN" not in address
 
     @pytest.mark.asyncio
     async def test_consumer_session_cleanup_on_connection_failure(self):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -469,7 +469,9 @@ class TestIntegration:
             pytest.skip("LocalStack may not fully support ARN addressing")
 
         # Create a mock ARN for the stream
-        stream_arn = f"arn:aws:kinesis:us-east-1:123456789012:stream/{random_stream_name}"
+        stream_arn = (
+            f"arn:aws:kinesis:us-east-1:123456789012:stream/{random_stream_name}"
+        )
 
         test_messages = [
             {"arn_test": i, "message": f"arn-message-{i}"} for i in range(3)

--- a/tests/test_producer.py
+++ b/tests/test_producer.py
@@ -304,7 +304,10 @@ class TestProducer:
             ("test-stream", False),
             ("my_stream", False),
             ("stream-123", False),
-            ("arnot:aws:kinesis:us-east-1:123456789012:stream/test", False),  # Invalid prefix
+            (
+                "arnot:aws:kinesis:us-east-1:123456789012:stream/test",
+                False,
+            ),  # Invalid prefix
             ("arn-test-stream", False),  # Starts with arn but not a valid ARN
         ]
 

--- a/tests/test_producer.py
+++ b/tests/test_producer.py
@@ -273,3 +273,54 @@ class TestProducer:
                 "auth-fail-test-stream", processor=JsonProcessor(), retry_limit=1
             ) as producer:
                 await producer.put({"test": "data"})
+
+    @pytest.mark.asyncio
+    async def test_producer_with_stream_arn(self, endpoint_url):
+        """Test producer with stream ARN instead of name (PR #39)."""
+        # Create a mock ARN
+        stream_arn = "arn:aws:kinesis:us-east-1:123456789012:stream/test-producer-arn"
+
+        producer = Producer(
+            stream_name=stream_arn,
+            endpoint_url=endpoint_url,
+            create_stream=False,
+        )
+
+        # Verify that the address property returns StreamARN
+        address = producer.address
+        assert "StreamARN" in address
+        assert address["StreamARN"] == stream_arn
+        assert "StreamName" not in address
+
+    @pytest.mark.asyncio
+    async def test_producer_arn_format_validation(self, endpoint_url):
+        """Test producer correctly handles various ARN formats (PR #39)."""
+        test_cases = [
+            # (stream_name, should_be_arn)
+            ("arn:aws:kinesis:us-east-1:123456789012:stream/test", True),
+            ("arn:aws:kinesis:eu-west-1:999999999999:stream/my-stream", True),
+            ("arn:aws-cn:kinesis:cn-north-1:123456789012:stream/test", True),
+            ("arn:aws-us-gov:kinesis:us-gov-west-1:123456789012:stream/test", True),
+            ("test-stream", False),
+            ("my_stream", False),
+            ("stream-123", False),
+            ("arnot:aws:kinesis:us-east-1:123456789012:stream/test", False),  # Invalid prefix
+            ("arn-test-stream", False),  # Starts with arn but not a valid ARN
+        ]
+
+        for stream_name, should_be_arn in test_cases:
+            producer = Producer(
+                stream_name=stream_name,
+                endpoint_url=endpoint_url,
+                create_stream=False,
+            )
+            address = producer.address
+
+            if should_be_arn:
+                assert "StreamARN" in address
+                assert address["StreamARN"] == stream_name
+                assert "StreamName" not in address
+            else:
+                assert "StreamName" in address
+                assert address["StreamName"] == stream_name
+                assert "StreamARN" not in address


### PR DESCRIPTION
followup tests for #39 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added and updated tests to verify correct handling and validation of stream ARNs (Amazon Resource Names) versus regular stream names in both producer and consumer components.
  - Enhanced test coverage to ensure accurate address formatting and recognition of ARNs in various scenarios.
  - Introduced integration tests to confirm end-to-end support for producing and consuming messages using stream ARNs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->