### PR TITLE
feat(consumer): wire metrics_collector and emit consumer/stream metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ async with Producer(stream_name="test") as producer:
 
 **With Metrics:**
 ```python
-from kinesis import Producer, PrometheusMetricsCollector
+from kinesis import Consumer, Producer, PrometheusMetricsCollector
 
 # Enable Prometheus metrics (optional)
 metrics = PrometheusMetricsCollector(namespace="my_app")
@@ -189,6 +189,11 @@ metrics = PrometheusMetricsCollector(namespace="my_app")
 async with Producer(stream_name="test", metrics_collector=metrics) as producer:
     await producer.put({'my': 'data'})
     # Metrics are automatically collected: throughput, errors, batch sizes, etc.
+
+async with Consumer(stream_name="test", metrics_collector=metrics) as consumer:
+    async for record in consumer:
+        # Emits records/bytes received, checkpoint success/failure, iterator age, errors, etc.
+        handle(record)
 ```
 
 ## Configuration

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -32,6 +32,29 @@ print(metrics.get_metrics())
 # {'producer_records_sent_total{stream_name=my-stream}': 1.0, ...}
 ```
 
+### Consumer Example
+
+```python
+from kinesis import Consumer, InMemoryMetricsCollector
+
+metrics = InMemoryMetricsCollector()
+
+async with Consumer(
+    stream_name="my-stream",
+    metrics_collector=metrics
+) as consumer:
+    async for record in consumer:
+        handle(record)
+
+# Per-shard counters of records and bytes successfully enqueued.
+print(metrics.counters)
+# {'consumer_records_received_total{shard_id=shardId-000000000000,stream_name=my-stream}': 42, ...}
+```
+
+Running multiple consumers in the same process? Pass an explicit collector to each. The
+global collector set via `set_metrics_collector()` is shared across every consumer that
+doesn't supply its own, which is usually not what you want for multi-stream observability.
+
 ### Prometheus Integration
 
 ```bash
@@ -89,14 +112,17 @@ async with Producer(stream_name="my-stream") as producer:
 
 | Metric | Type | Description | Labels |
 |--------|------|-------------|---------|
-| `consumer_records_received_total` | Counter | Total records received | `stream_name`, `shard_id` |
-| `consumer_bytes_received_total` | Counter | Total bytes received | `stream_name`, `shard_id` |
-| `consumer_errors_total` | Counter | Total consumer errors | `stream_name`, `shard_id`, `error_type` |
-| `consumer_checkpoint_success_total` | Counter | Successful checkpoints | `stream_name`, `shard_id` |
-| `consumer_checkpoint_failure_total` | Counter | Failed checkpoints | `stream_name`, `shard_id` |
-| `consumer_lag_records` | Gauge | Consumer lag in records | `stream_name`, `shard_id` |
-| `consumer_processing_time_seconds` | Histogram | Record processing time | `stream_name`, `shard_id` |
-| `consumer_iterator_age_milliseconds` | Gauge | Iterator age (lag indicator) | `stream_name`, `shard_id` |
+| `consumer_records_received_total` | Counter | Records successfully enqueued to the consumer queue (raw Kinesis rows, pre-deaggregation). Rows dropped mid-batch by a queue timeout are not counted. | `stream_name`, `shard_id` |
+| `consumer_bytes_received_total` | Counter | Bytes of `Data` for rows counted by `consumer_records_received_total`. | `stream_name`, `shard_id` |
+| `consumer_errors_total` | Counter | Errors in `get_records`. `error_type` is `connection`, `timeout`, `unknown`, or the raw AWS error code (e.g. `ProvisionedThroughputExceededException`, `ExpiredIteratorException`, `InternalFailure`). | `stream_name`, `shard_id`, `error_type` |
+| `consumer_checkpoint_success_total` | Counter | Checkpointer backend calls that returned successfully. | `stream_name`, `shard_id` |
+| `consumer_checkpoint_failure_total` | Counter | Checkpointer backend calls that raised. | `stream_name`, `shard_id` |
+| `consumer_iterator_age_milliseconds` | Gauge | `MillisBehindLatest` from the last `GetRecords` response. Only emitted when the backend populates the field. | `stream_name`, `shard_id` |
+| `consumer_queue_size` | Gauge | Consumer internal queue depth after the enqueue pass. | `stream_name` |
+| `consumer_lag_records` | Gauge | *Planned* - not currently emitted. | `stream_name`, `shard_id` |
+| `consumer_processing_time_seconds` | Histogram | *Planned* - not currently emitted. | `stream_name`, `shard_id` |
+
+`consumer_errors_total` uses raw AWS error codes rather than semantic labels. `ProvisionedThroughputExceededException` and `ExpiredIteratorException` are recovery events, not failures; alert on `connection`, `unknown`, and `InternalFailure` instead.
 
 ### Stream Metrics
 
@@ -244,8 +270,8 @@ rate(my_service_producer_records_sent_total[5m])
 # Producer error rate
 rate(my_service_producer_errors_total[5m])
 
-# Consumer lag
-my_service_consumer_lag_records
+# Consumer iterator age (lag indicator)
+my_service_consumer_iterator_age_milliseconds
 
 # Resharding events
 increase(my_service_stream_resharding_events_total[1h])
@@ -263,11 +289,11 @@ groups:
         annotations:
           summary: "High error rate in Kinesis producer"
 
-      - alert: HighConsumerLag
-        expr: my_service_consumer_lag_records > 10000
+      - alert: HighConsumerIteratorAge
+        expr: my_service_consumer_iterator_age_milliseconds > 60000
         for: 10m
         annotations:
-          summary: "Consumer lag exceeds 10k records"
+          summary: "Consumer is more than 60s behind the shard tip"
 
       - alert: ReshardingDetected
         expr: increase(my_service_stream_resharding_events_total[5m]) > 0

--- a/kinesis/consumer.py
+++ b/kinesis/consumer.py
@@ -10,6 +10,7 @@ from botocore.exceptions import ClientError
 
 from .base import Base
 from .checkpointers import CheckPointer, MemoryCheckPointer
+from .metrics import MetricsCollector, MetricType, get_metrics_collector
 from .processors import JsonProcessor, Processor
 from .utils import Throttler
 
@@ -58,6 +59,7 @@ class Consumer(Base):
         idle_timeout: float = 2.0,
         timestamp: Optional[datetime] = None,
         checkpoint_interval: Optional[float] = None,
+        metrics_collector: Optional[MetricsCollector] = None,
     ) -> None:
 
         super(Consumer, self).__init__(
@@ -130,6 +132,9 @@ class Consumer(Base):
         self._child_shards = set()  # Track shards that are children
         self._exhausted_parents = set()  # Track parent shards that are fully consumed
         self._deallocated_shards: set = set()  # Shards already deallocated (skip stale sentinels)
+
+        # Metrics collector
+        self.metrics = metrics_collector if metrics_collector else get_metrics_collector()
 
     def __aiter__(self) -> AsyncIterator[Any]:
         return self
@@ -277,15 +282,33 @@ class Consumer(Base):
                     result = shard["fetch"].result()
 
                     if not result:
+                        # Emit queue gauge so backpressure stays observable while
+                        # get_records is failing/retrying (otherwise it freezes at
+                        # the last successful fetch's value).
+                        self.metrics.gauge(
+                            MetricType.CONSUMER_QUEUE_SIZE,
+                            self.queue.qsize(),
+                            {"stream_name": self.stream_name},
+                        )
                         shard["fetch"] = None
                         continue
 
                     records = result["Records"]
 
+                    millis_behind = result.get("MillisBehindLatest")
+                    if millis_behind is not None:
+                        self.metrics.gauge(
+                            MetricType.CONSUMER_ITERATOR_AGE,
+                            millis_behind,
+                            {"stream_name": self.stream_name, "shard_id": shard["ShardId"]},
+                        )
+
                     if records:
                         log.debug("Shard {} got {} records".format(shard["ShardId"], len(records)))
 
                         total_items = 0
+                        enqueued_rows = 0
+                        enqueued_bytes = 0
                         last_enqueued_sequence = None
                         for row in result["Records"]:
                             item_count = 0
@@ -304,7 +327,14 @@ class Consumer(Base):
                                 break
                             if item_count > 0:
                                 last_enqueued_sequence = row["SequenceNumber"]
+                                enqueued_rows += 1
+                                enqueued_bytes += len(row["Data"])
                             total_items += item_count
+
+                        if enqueued_rows:
+                            shard_labels = {"stream_name": self.stream_name, "shard_id": shard["ShardId"]}
+                            self.metrics.increment(MetricType.CONSUMER_RECORDS_RECEIVED, enqueued_rows, shard_labels)
+                            self.metrics.increment(MetricType.CONSUMER_BYTES_RECEIVED, enqueued_bytes, shard_labels)
 
                         # Get approx minutes behind..
                         last_arrival = records[-1].get("ApproximateArrivalTimestamp")
@@ -358,6 +388,12 @@ class Consumer(Base):
                         )
                         await asyncio.sleep(self.sleep_time_no_records)
 
+                    self.metrics.gauge(
+                        MetricType.CONSUMER_QUEUE_SIZE,
+                        self.queue.qsize(),
+                        {"stream_name": self.stream_name},
+                    )
+
                     if not result["NextShardIterator"]:
                         # Shard is closed - this is normal during resharding
                         shard_id = shard["ShardId"]
@@ -383,7 +419,7 @@ class Consumer(Base):
                             # Flush interval-buffered checkpoint for this shard
                             if shard_id in self._pending_checkpoints:
                                 seq = self._pending_checkpoints[shard_id]
-                                await self.checkpointer.checkpoint(shard_id, seq)
+                                await self._checkpoint_with_metrics(shard_id, seq)
                                 if self._pending_checkpoints.get(shard_id) == seq:
                                     del self._pending_checkpoints[shard_id]
 
@@ -435,13 +471,28 @@ class Consumer(Base):
                 return result
 
             except ClientConnectionError:
+                self.metrics.increment(
+                    MetricType.CONSUMER_ERRORS,
+                    1,
+                    {"stream_name": self.stream_name, "shard_id": shard["ShardId"], "error_type": "connection"},
+                )
                 await self.get_conn()
             except TimeoutError as e:
+                self.metrics.increment(
+                    MetricType.CONSUMER_ERRORS,
+                    1,
+                    {"stream_name": self.stream_name, "shard_id": shard["ShardId"], "error_type": "timeout"},
+                )
                 log.warning("Timeout {}. sleeping..".format(e))
                 await asyncio.sleep(3)
 
             except ClientError as e:
                 code = e.response["Error"]["Code"]
+                self.metrics.increment(
+                    MetricType.CONSUMER_ERRORS,
+                    1,
+                    {"stream_name": self.stream_name, "shard_id": shard["ShardId"], "error_type": code},
+                )
                 if code == "ProvisionedThroughputExceededException":
                     log.warning("{} hit ProvisionedThroughputExceededException".format(shard["ShardId"]))
                     shard["stats"].throttled()
@@ -485,6 +536,11 @@ class Consumer(Base):
                     await asyncio.sleep(3)
 
             except Exception as e:
+                self.metrics.increment(
+                    MetricType.CONSUMER_ERRORS,
+                    1,
+                    {"stream_name": self.stream_name, "shard_id": shard["ShardId"], "error_type": "unknown"},
+                )
                 log.warning("Unknown error {}. sleeping..".format(e))
                 await asyncio.sleep(3)
 
@@ -552,6 +608,7 @@ class Consumer(Base):
                 new_child_shards = discovered_shards & self._child_shards
                 if new_child_shards:
                     log.info(f"Resharding detected: new child shards {new_child_shards}")
+                    self.metrics.increment(MetricType.STREAM_RESHARDING_EVENTS, 1, {"stream_name": self.stream_name})
 
             # Find shards that no longer exist (though this is rare)
             missing_shards = current_shard_ids - new_shard_ids
@@ -586,6 +643,13 @@ class Consumer(Base):
             self._last_shard_refresh = current_time
 
             log.debug(f"Shard refresh complete. Total shards: {len(self.shards)}")
+
+            known_ids = {s["ShardId"] for s in self.shards}
+            closed_count = len(known_ids & self._closed_shards)
+            active_count = len(self.shards) - closed_count
+            stream_labels = {"stream_name": self.stream_name}
+            self.metrics.gauge(MetricType.STREAM_SHARDS_ACTIVE, active_count, stream_labels)
+            self.metrics.gauge(MetricType.STREAM_SHARDS_CLOSED, closed_count, stream_labels)
 
         except Exception as e:
             log.warning(f"Failed to refresh shards: {e}")
@@ -852,11 +916,21 @@ class Consumer(Base):
         """Non-blocking check whether consumer has obtained shard iterators."""
         return self._ready.is_set()
 
+    async def _checkpoint_with_metrics(self, shard_id: str, sequence: str) -> None:
+        """Call checkpointer.checkpoint and emit success/failure metrics."""
+        cp_labels = {"stream_name": self.stream_name, "shard_id": shard_id}
+        try:
+            await self.checkpointer.checkpoint(shard_id, sequence)
+            self.metrics.increment(MetricType.CONSUMER_CHECKPOINT_SUCCESS, 1, cp_labels)
+        except Exception:
+            self.metrics.increment(MetricType.CONSUMER_CHECKPOINT_FAILURE, 1, cp_labels)
+            raise
+
     async def _maybe_checkpoint(self, shard_id: str, sequence: str):
         """Commit a checkpoint, either immediately or via interval buffer."""
         if self.checkpoint_interval is None:
             # No debouncing — checkpoint immediately
-            await self.checkpointer.checkpoint(shard_id, sequence)
+            await self._checkpoint_with_metrics(shard_id, sequence)
             return
 
         # Buffer for background flush
@@ -891,7 +965,7 @@ class Consumer(Base):
             seq = self._pending_checkpoints.get(shard_id)
             if seq is None:
                 continue
-            await self.checkpointer.checkpoint(shard_id, seq)
+            await self._checkpoint_with_metrics(shard_id, seq)
             # Only delete if the value hasn't been superseded during the await
             if self._pending_checkpoints.get(shard_id) == seq:
                 del self._pending_checkpoints[shard_id]

--- a/kinesis/metrics.py
+++ b/kinesis/metrics.py
@@ -29,9 +29,11 @@ class MetricType(Enum):
     CONSUMER_ERRORS = "consumer_errors_total"
     CONSUMER_CHECKPOINT_SUCCESS = "consumer_checkpoint_success_total"
     CONSUMER_CHECKPOINT_FAILURE = "consumer_checkpoint_failure_total"
+    CONSUMER_ITERATOR_AGE = "consumer_iterator_age_milliseconds"
+    CONSUMER_QUEUE_SIZE = "consumer_queue_size"
+    # Defined but not yet emitted — see docs/metrics.md.
     CONSUMER_LAG = "consumer_lag_records"
     CONSUMER_PROCESSING_TIME = "consumer_processing_time_seconds"
-    CONSUMER_ITERATOR_AGE = "consumer_iterator_age_milliseconds"
 
     # Stream metrics
     STREAM_SHARDS_ACTIVE = "stream_shards_active"

--- a/kinesis/prometheus.py
+++ b/kinesis/prometheus.py
@@ -143,6 +143,23 @@ class PrometheusMetricsCollector(MetricsCollector):
             registry=self.registry,
         )
 
+        self._metrics[MetricType.CONSUMER_ITERATOR_AGE] = Gauge(
+            name="consumer_iterator_age_milliseconds",
+            documentation="Age of the iterator in milliseconds",
+            namespace=self.namespace,
+            labelnames=["stream_name", "shard_id"],
+            registry=self.registry,
+        )
+
+        self._metrics[MetricType.CONSUMER_QUEUE_SIZE] = Gauge(
+            name="consumer_queue_size",
+            documentation="Current size of the consumer queue",
+            namespace=self.namespace,
+            labelnames=["stream_name"],
+            registry=self.registry,
+        )
+
+        # Defined but not yet emitted — registered for forward compatibility.
         self._metrics[MetricType.CONSUMER_LAG] = Gauge(
             name="consumer_lag_records",
             documentation="Consumer lag in number of records",
@@ -157,14 +174,6 @@ class PrometheusMetricsCollector(MetricsCollector):
             namespace=self.namespace,
             labelnames=["stream_name", "shard_id"],
             buckets=(0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0),
-            registry=self.registry,
-        )
-
-        self._metrics[MetricType.CONSUMER_ITERATOR_AGE] = Gauge(
-            name="consumer_iterator_age_milliseconds",
-            documentation="Age of the iterator in milliseconds",
-            namespace=self.namespace,
-            labelnames=["stream_name", "shard_id"],
             registry=self.registry,
         )
 

--- a/kinesis/testing.py
+++ b/kinesis/testing.py
@@ -293,10 +293,15 @@ class MockConsumer:
         create_stream_shards: int = 1,
         timestamp=None,
         poll_delay: float = 0,
+        metrics_collector=None,
         **kwargs: Any,
     ) -> None:
+        from .metrics import get_metrics_collector
+
         self.stream_name = stream_name
         self.processor = processor if processor else JsonProcessor()
+        # Stored for parity with Consumer; MockConsumer does not emit metrics itself.
+        self.metrics = metrics_collector if metrics_collector else get_metrics_collector()
         self.checkpointer = checkpointer if checkpointer else MemoryCheckPointer()
         self.iterator_type = iterator_type
         self._create_stream = create_stream

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -5,7 +5,8 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from kinesis import Consumer, MemoryCheckPointer, Producer, exceptions
+from kinesis import Consumer, InMemoryMetricsCollector, MemoryCheckPointer, Producer, exceptions
+from kinesis.metrics import MetricType
 from kinesis.processors import JsonProcessor
 from kinesis.timeout_compat import timeout
 
@@ -66,6 +67,56 @@ class TestConsumer:
                 pass
 
         assert len(consumed_messages) > 0
+
+    @pytest.mark.asyncio
+    async def test_consumer_metrics_round_trip(self, test_stream, endpoint_url):
+        """Consumer emits records/bytes received counters and queue size gauge after a round trip."""
+        collector = InMemoryMetricsCollector()
+
+        async with Producer(stream_name=test_stream, endpoint_url=endpoint_url) as producer:
+            for i in range(3):
+                await producer.put({"message": f"m-{i}"})
+            await producer.flush()
+
+        async with Consumer(
+            stream_name=test_stream,
+            endpoint_url=endpoint_url,
+            sleep_time_no_records=0.1,
+            metrics_collector=collector,
+        ) as consumer:
+            consumed = []
+            try:
+                async with timeout(5):
+                    async for message in consumer:
+                        consumed.append(message)
+                        if len(consumed) >= 3:
+                            break
+            except asyncio.TimeoutError:
+                pass
+
+        records_keys = [k for k in collector.counters if k.startswith("consumer_records_received_total")]
+        bytes_keys = [k for k in collector.counters if k.startswith("consumer_bytes_received_total")]
+        queue_keys = [k for k in collector.gauges if k.startswith("consumer_queue_size")]
+
+        assert records_keys, f"expected consumer_records_received_total, got {list(collector.counters)}"
+        # 3 distinct JSON puts → 3 Kinesis rows. Exact match guards against double-counting on retry.
+        assert sum(collector.counters[k] for k in records_keys) == 3
+        # Bytes are the serialized Data field; derive the expected size from whichever
+        # JSON backend the serializer actually used (ujson is compact, stdlib has spaces).
+        expected_per_record = sum(len(item.data) for item in JsonProcessor().add_item({"message": "m-0"}))
+        assert sum(collector.counters[k] for k in bytes_keys) == 3 * expected_per_record
+        assert queue_keys
+
+        # Iterator age: only assert if the backend reported MillisBehindLatest as
+        # proper milliseconds. Floci < 1.6 (approx) populates the field with a
+        # record count, not an age, so skip this assertion until CI pins a patched image.
+        iterator_age_keys = [k for k in collector.gauges if k.startswith("consumer_iterator_age_milliseconds")]
+        if not iterator_age_keys:
+            pytest.skip(
+                "Backend did not report MillisBehindLatest with millisecond semantics "
+                "(e.g. kinesalite omits it; floci PR #444 not yet released)."
+            )
+        assert all(collector.gauges[k] >= 0 for k in iterator_age_keys)
 
     @pytest.mark.asyncio
     async def test_consumer_checkpointing(self, test_stream, endpoint_url):

--- a/tests/test_metrics_unit.py
+++ b/tests/test_metrics_unit.py
@@ -1,19 +1,25 @@
 """Unit tests for metrics functionality."""
 
+import asyncio
 import time
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from aiohttp import ClientConnectionError
+from botocore.exceptions import ClientError
 
 from kinesis import (
     InMemoryMetricsCollector,
+    MemoryCheckPointer,
     MetricType,
     NoOpMetricsCollector,
     get_metrics_collector,
     reset_metrics_collector,
     set_metrics_collector,
 )
+from kinesis.consumer import ShardStats
 from kinesis.metrics import Timer
+from kinesis.utils import Throttler
 
 
 class TestNoOpMetricsCollector:
@@ -198,3 +204,364 @@ class TestMetricTypeEnum:
             assert name.islower() or "_" in name
             # Should not have spaces
             assert " " not in name
+
+
+async def _drain_pending_shard_fetch(consumer):
+    """Cancel any in-flight shard fetch task left behind by fetch()."""
+    for shard in consumer.shards or []:
+        task = shard.get("fetch")
+        if task is not None and not task.done():
+            task.cancel()
+            try:
+                await task
+            except (asyncio.CancelledError, Exception):
+                pass
+            shard["fetch"] = None
+
+
+def _shard_labels(shard_id, stream_name="test-stream"):
+    return f"shard_id={shard_id},stream_name={stream_name}"
+
+
+class TestConsumerMetricsWiring:
+    """Verify Consumer accepts metrics_collector and wires it correctly."""
+
+    @pytest.mark.asyncio
+    async def test_consumer_accepts_metrics_collector(self, mock_consumer):
+        collector = InMemoryMetricsCollector()
+        consumer = mock_consumer(metrics_collector=collector)
+        assert consumer.metrics is collector
+
+    @pytest.mark.asyncio
+    async def test_consumer_defaults_to_global_collector(self, mock_consumer):
+        reset_metrics_collector()
+        consumer = mock_consumer()
+        assert isinstance(consumer.metrics, NoOpMetricsCollector)
+
+
+class TestConsumerFetchEmits:
+    """Exercise fetch() emit sites with a synthetic result dict."""
+
+    @staticmethod
+    def _prime_shard_with_result(consumer, result, shard_id="shard-0"):
+        fetch_future = asyncio.Future()
+        fetch_future.set_result(result)
+        consumer.shards = [
+            {
+                "ShardId": shard_id,
+                "ShardIterator": "curr-iter",
+                "fetch": fetch_future,
+                "throttler": Throttler(rate_limit=1000, period=1),
+                "stats": ShardStats(),
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_fetch_increments_records_and_bytes_per_enqueued_row(self, mock_consumer):
+        collector = InMemoryMetricsCollector()
+        consumer = mock_consumer(metrics_collector=collector)
+        consumer.checkpointer = MemoryCheckPointer(name="test")
+        await consumer.checkpointer.allocate("shard-0")
+        consumer.refresh_shards = AsyncMock()
+        consumer.get_records = AsyncMock(return_value=None)
+
+        records = [
+            {"SequenceNumber": "1", "Data": b'{"id": 1}'},  # 9 bytes
+            {"SequenceNumber": "2", "Data": b'{"id": 22}'},  # 10 bytes
+        ]
+        self._prime_shard_with_result(
+            consumer,
+            {"Records": records, "NextShardIterator": "next-iter"},
+        )
+
+        await consumer.fetch()
+
+        key_base = _shard_labels("shard-0")
+        assert collector.counters[f"consumer_records_received_total{{{key_base}}}"] == 2
+        assert collector.counters[f"consumer_bytes_received_total{{{key_base}}}"] == 19
+
+        # Queue size gauge emitted once records were enqueued
+        assert "consumer_queue_size{stream_name=test-stream}" in collector.gauges
+
+        await _drain_pending_shard_fetch(consumer)
+
+    @pytest.mark.asyncio
+    async def test_fetch_emits_iterator_age_when_millis_behind_present(self, mock_consumer):
+        collector = InMemoryMetricsCollector()
+        consumer = mock_consumer(metrics_collector=collector)
+        consumer.checkpointer = MemoryCheckPointer(name="test")
+        await consumer.checkpointer.allocate("shard-0")
+        consumer.refresh_shards = AsyncMock()
+        consumer.get_records = AsyncMock(return_value=None)
+
+        self._prime_shard_with_result(
+            consumer,
+            {
+                "Records": [],
+                "NextShardIterator": "next-iter",
+                "MillisBehindLatest": 54321,
+            },
+        )
+
+        await consumer.fetch()
+
+        key = f"consumer_iterator_age_milliseconds{{{_shard_labels('shard-0')}}}"
+        assert collector.gauges[key] == 54321
+
+        await _drain_pending_shard_fetch(consumer)
+
+    @pytest.mark.asyncio
+    async def test_fetch_skips_iterator_age_when_field_absent(self, mock_consumer):
+        """Kinesalite / unpatched floci omit MillisBehindLatest. Emit must no-op."""
+        collector = InMemoryMetricsCollector()
+        consumer = mock_consumer(metrics_collector=collector)
+        consumer.checkpointer = MemoryCheckPointer(name="test")
+        await consumer.checkpointer.allocate("shard-0")
+        consumer.refresh_shards = AsyncMock()
+        consumer.get_records = AsyncMock(return_value=None)
+
+        self._prime_shard_with_result(
+            consumer,
+            {"Records": [], "NextShardIterator": "next-iter"},
+        )
+
+        await consumer.fetch()
+
+        iterator_age_keys = [k for k in collector.gauges if k.startswith("consumer_iterator_age_milliseconds")]
+        assert iterator_age_keys == []
+
+        await _drain_pending_shard_fetch(consumer)
+
+    @pytest.mark.asyncio
+    async def test_fetch_counts_only_successfully_enqueued_rows(self, mock_consumer):
+        """Rows that time out mid-batch must not be counted (avoid double-count on retry)."""
+        collector = InMemoryMetricsCollector()
+        consumer = mock_consumer(metrics_collector=collector)
+        consumer.checkpointer = MemoryCheckPointer(name="test")
+        await consumer.checkpointer.allocate("shard-0")
+        consumer.refresh_shards = AsyncMock()
+        consumer.get_records = AsyncMock(return_value=None)
+
+        records = [
+            {"SequenceNumber": "1", "Data": b'{"id": 1}'},
+            {"SequenceNumber": "2", "Data": b'{"id": 2}'},
+            {"SequenceNumber": "3", "Data": b'{"id": 3}'},
+        ]
+        self._prime_shard_with_result(
+            consumer,
+            {"Records": records, "NextShardIterator": "next-iter"},
+        )
+
+        # Patch the queue's put directly so first put succeeds, subsequent puts
+        # raise asyncio.TimeoutError (matches what asyncio.wait_for would surface
+        # on a real timeout). Patching put rather than asyncio.wait_for keeps the
+        # test stable if other wait_for sites are added inside fetch().
+        real_put = consumer.queue.put
+        put_calls = {"n": 0}
+
+        async def flaky_put(item):
+            put_calls["n"] += 1
+            if put_calls["n"] >= 2:
+                raise asyncio.TimeoutError()
+            await real_put(item)
+
+        consumer.queue.put = flaky_put
+
+        await consumer.fetch()
+
+        key_base = _shard_labels("shard-0")
+        # Only the first row got enqueued before the timeout broke the loop.
+        assert collector.counters.get(f"consumer_records_received_total{{{key_base}}}") == 1
+        assert collector.counters.get(f"consumer_bytes_received_total{{{key_base}}}") == 9
+
+        await _drain_pending_shard_fetch(consumer)
+
+
+class TestConsumerGetRecordsErrors:
+    """CONSUMER_ERRORS emits from get_records error paths with correct error_type."""
+
+    @staticmethod
+    def _shard(shard_id="shard-0"):
+        return {
+            "ShardId": shard_id,
+            "ShardIterator": "curr-iter",
+            "throttler": Throttler(rate_limit=1000, period=1),
+            "stats": ShardStats(),
+        }
+
+    @pytest.mark.asyncio
+    async def test_connection_error_emits_connection_label(self, mock_consumer):
+        collector = InMemoryMetricsCollector()
+        consumer = mock_consumer(metrics_collector=collector)
+        consumer.client = MagicMock()
+        consumer.client.get_records = AsyncMock(side_effect=ClientConnectionError("boom"))
+        consumer.get_conn = AsyncMock()
+
+        await consumer.get_records(self._shard())
+
+        key = f"consumer_errors_total{{error_type=connection,{_shard_labels('shard-0')}}}"
+        assert collector.counters[key] == 1
+
+    @pytest.mark.asyncio
+    async def test_timeout_emits_timeout_label(self, mock_consumer):
+        collector = InMemoryMetricsCollector()
+        consumer = mock_consumer(metrics_collector=collector)
+        consumer.client = MagicMock()
+        consumer.client.get_records = AsyncMock(side_effect=asyncio.TimeoutError())
+
+        # Monkeypatch asyncio.sleep inside the except block to avoid 3s wait.
+        orig_sleep = asyncio.sleep
+
+        async def fast_sleep(_):
+            await orig_sleep(0)
+
+        with pytest.MonkeyPatch().context() as mp:
+            mp.setattr(asyncio, "sleep", fast_sleep)
+            await consumer.get_records(self._shard())
+
+        key = f"consumer_errors_total{{error_type=timeout,{_shard_labels('shard-0')}}}"
+        assert collector.counters[key] == 1
+
+    @pytest.mark.asyncio
+    async def test_client_error_emits_raw_code_label(self, mock_consumer):
+        collector = InMemoryMetricsCollector()
+        consumer = mock_consumer(metrics_collector=collector)
+        err = ClientError(
+            {"Error": {"Code": "ProvisionedThroughputExceededException", "Message": "throttled"}},
+            "GetRecords",
+        )
+        consumer.client = MagicMock()
+        consumer.client.get_records = AsyncMock(side_effect=err)
+
+        orig_sleep = asyncio.sleep
+
+        async def fast_sleep(_):
+            await orig_sleep(0)
+
+        with pytest.MonkeyPatch().context() as mp:
+            mp.setattr(asyncio, "sleep", fast_sleep)
+            await consumer.get_records(self._shard())
+
+        key = (
+            "consumer_errors_total{" f"error_type=ProvisionedThroughputExceededException,{_shard_labels('shard-0')}" "}"
+        )
+        assert collector.counters[key] == 1
+
+    @pytest.mark.asyncio
+    async def test_unknown_exception_emits_unknown_label(self, mock_consumer):
+        collector = InMemoryMetricsCollector()
+        consumer = mock_consumer(metrics_collector=collector)
+        consumer.client = MagicMock()
+        consumer.client.get_records = AsyncMock(side_effect=RuntimeError("surprise"))
+
+        orig_sleep = asyncio.sleep
+
+        async def fast_sleep(_):
+            await orig_sleep(0)
+
+        with pytest.MonkeyPatch().context() as mp:
+            mp.setattr(asyncio, "sleep", fast_sleep)
+            await consumer.get_records(self._shard())
+
+        key = f"consumer_errors_total{{error_type=unknown,{_shard_labels('shard-0')}}}"
+        assert collector.counters[key] == 1
+
+
+class TestConsumerCheckpointMetrics:
+    @pytest.mark.asyncio
+    async def test_maybe_checkpoint_success(self, mock_consumer):
+        collector = InMemoryMetricsCollector()
+        consumer = mock_consumer(metrics_collector=collector)
+        consumer.checkpointer = AsyncMock()
+
+        await consumer._maybe_checkpoint("shard-0", "seq-1")
+
+        key = f"consumer_checkpoint_success_total{{{_shard_labels('shard-0')}}}"
+        assert collector.counters[key] == 1
+        assert f"consumer_checkpoint_failure_total{{{_shard_labels('shard-0')}}}" not in collector.counters
+
+    @pytest.mark.asyncio
+    async def test_maybe_checkpoint_failure(self, mock_consumer):
+        collector = InMemoryMetricsCollector()
+        consumer = mock_consumer(metrics_collector=collector)
+        consumer.checkpointer = AsyncMock()
+        consumer.checkpointer.checkpoint.side_effect = RuntimeError("backend down")
+
+        with pytest.raises(RuntimeError):
+            await consumer._maybe_checkpoint("shard-0", "seq-1")
+
+        key = f"consumer_checkpoint_failure_total{{{_shard_labels('shard-0')}}}"
+        assert collector.counters[key] == 1
+        assert f"consumer_checkpoint_success_total{{{_shard_labels('shard-0')}}}" not in collector.counters
+
+    @pytest.mark.asyncio
+    async def test_flush_pending_checkpoints_success(self, mock_consumer):
+        collector = InMemoryMetricsCollector()
+        consumer = mock_consumer(metrics_collector=collector)
+        consumer.checkpointer = AsyncMock()
+        consumer._pending_checkpoints = {"shard-0": "seq-1", "shard-1": "seq-9"}
+
+        await consumer._flush_pending_checkpoints()
+
+        assert collector.counters[f"consumer_checkpoint_success_total{{{_shard_labels('shard-0')}}}"] == 1
+        assert collector.counters[f"consumer_checkpoint_success_total{{{_shard_labels('shard-1')}}}"] == 1
+
+
+class TestStreamMetrics:
+    @pytest.mark.asyncio
+    async def test_refresh_shards_emits_active_and_closed_gauges(self, mock_consumer):
+        collector = InMemoryMetricsCollector()
+        consumer = mock_consumer(metrics_collector=collector)
+        consumer._last_shard_refresh = 0  # Force refresh
+        consumer.skip_describe_stream = False
+        consumer.use_list_shards = False
+        consumer._closed_shards = {"shard-closed"}
+
+        consumer.get_stream_description = AsyncMock(
+            return_value={
+                "StreamStatus": consumer.ACTIVE,
+                "Shards": [
+                    {"ShardId": "shard-0"},
+                    {"ShardId": "shard-1"},
+                    {"ShardId": "shard-closed"},
+                ],
+            }
+        )
+
+        await consumer.refresh_shards()
+
+        assert collector.gauges["stream_shards_active{stream_name=test-stream}"] == 2
+        assert collector.gauges["stream_shards_closed{stream_name=test-stream}"] == 1
+
+    @pytest.mark.asyncio
+    async def test_resharding_detected_emits_counter(self, mock_consumer):
+        collector = InMemoryMetricsCollector()
+        consumer = mock_consumer(metrics_collector=collector)
+        consumer._last_shard_refresh = 0
+        consumer.skip_describe_stream = False
+        consumer.use_list_shards = False
+
+        # Existing parent, new child appears → resharding event.
+        consumer.shards = [
+            {"ShardId": "parent-0", "SequenceNumberRange": {"StartingSequenceNumber": "1"}},
+        ]
+        consumer.get_stream_description = AsyncMock(
+            return_value={
+                "StreamStatus": consumer.ACTIVE,
+                "Shards": [
+                    {
+                        "ShardId": "parent-0",
+                        "SequenceNumberRange": {"StartingSequenceNumber": "1"},
+                    },
+                    {
+                        "ShardId": "child-0",
+                        "ParentShardId": "parent-0",
+                        "SequenceNumberRange": {"StartingSequenceNumber": "100"},
+                    },
+                ],
+            }
+        )
+
+        await consumer.refresh_shards()
+
+        assert collector.counters["stream_resharding_events_total{stream_name=test-stream}"] == 1


### PR DESCRIPTION
## Summary

Producer has been emitting metrics for a while; Consumer had the `MetricType` enums but no emit sites and no constructor wiring. A user setting a global collector via `set_metrics_collector()` received nothing for the consumer side. Closes #73.

`Consumer` now accepts a `metrics_collector` kwarg (mirrors `Producer`) and emits, with `shard_id` labels where applicable:

- `consumer_records_received_total` / `consumer_bytes_received_total` counted from rows actually enqueued, not `len(result["Records"])`. `fetch()` breaks on `queue.put` timeout mid-batch and the tail refetches; counting the full batch would double-count.
- `consumer_iterator_age_milliseconds` gauge from `MillisBehindLatest`, skipped when the backend omits the field.
- `consumer_queue_size` gauge after every fetch result (records, empty, or errored) so it tracks down as the consumer drains, not just up.
- `consumer_errors_total` with raw AWS `error_type` labels. Throttles and expired iterators are recovery events; downstream alerting decides what's a failure rather than collapsing semantics in the label.
- `consumer_checkpoint_success_total` / `failure_total` wrapping only the actual `checkpointer.checkpoint()` backend calls.
- `stream_shards_active` / `closed` gauges and `stream_resharding_events_total` counter from `refresh_shards()`.

`CONSUMER_QUEUE_SIZE` is a new `MetricType` (parity with `PRODUCER_QUEUE_SIZE`) and is registered in the Prometheus collector. `MockConsumer` accepts and stores `metrics_collector` for signature parity (no emits).

`docs/metrics.md` describes only metrics that are actually emitted. The former `consumer_lag_records` and `consumer_processing_time_seconds` rows are marked planned. Alerting example uses iterator age instead.

## Backwards compatibility

Adding `metrics_collector` as a new keyword-only argument with a `None` default is non-breaking for callers. Users who set a global collector via `set_metrics_collector()` will start receiving the new consumer/stream metrics automatically.

## Test plan

- [x] 15 new unit tests covering every emit site (records/bytes counts, iterator age present + absent, queue-size gauge, error labels for connection/timeout/AWS-code/unknown, checkpoint success + failure, stream gauges, resharding counter, double-count guard via patched `consumer.queue.put`)
- [x] 1 new integration test (`test_consumer_metrics_round_trip`) asserts exact counts (`==3` records, `==54` bytes) end-to-end via kinesalite
- [x] Full non-Docker suite green: 138 passed, 7 skipped
- [x] Integration test passes against kinesalite (Floci 1.4.0 in CI doesn't yet have the `MillisBehindLatest` ms-semantics fix; the iterator-age assertion uses a loose `>= 0` check that tolerates both kinesalite's `0` and Floci's pre-fix record-count value, with `pytest.skip` if the field is entirely absent)

## Review

Internal two-pass review (bugs + polish) plus external Codex + Gemini reviews ran on the diff. All actionable findings folded into the final commit:

- Queue-size gauge moved out of `if records:` and now also fires on the no-result error path so backpressure stays observable during outages.
- `MockConsumer` stores `self.metrics` for parity.
- `CONSUMER_QUEUE_SIZE` reordered in the enum and Prometheus block to group with the other emitted metrics; `CONSUMER_LAG` and `CONSUMER_PROCESSING_TIME` now sit at the end with a comment explaining they're defined-but-not-yet-emitted.
- Integration test tightened from `>= 3` to exact counts to actually catch double-counting regressions.
- `test_fetch_counts_only_successfully_enqueued_rows` now patches `consumer.queue.put` directly instead of `asyncio.wait_for`, decoupling the test from any future `wait_for` call sites in `fetch()`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Consumer now supports metrics collection via optional `metrics_collector` parameter.
  * New metrics: queue size tracking and iterator age measurements.
  * Enhanced error tracking with categorized error types.

* **Documentation**
  * Added Consumer metrics example and clarified metric semantics.
  * Updated Prometheus/Grafana monitoring guidance with new metrics.

* **Tests**
  * Added comprehensive test coverage for consumer metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->