### PR TITLE
fix(checkpointer): emit checkpoint metrics on backend write, not consumer call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+## Unreleased
+
+### Fixed
+- `consumer_checkpoint_success_total` / `_failure_total` now count actual backend
+  persist operations. Previously, under `auto_checkpoint=False` (Redis / DynamoDB
+  manual mode), the consumer-side wrapper incremented success on every
+  `checkpoint()` call even though the backend write was deferred to
+  `manual_checkpoint()`. The counters now track durable writes, which means they
+  stay flat between flushes in manual mode and spike when the user flushes. Metric
+  label set unchanged (`{stream_name, shard_id}`); checkpointers used without a
+  Consumer appear under a new sentinel `stream_name="<standalone>"`.
+
+### Internal
+- Removed `Consumer._checkpoint_with_metrics` (private, added in v2.5.0 four days
+  prior). Callers invoke `checkpointer.checkpoint()` directly; emission now lives
+  on `BaseCheckPointer` via `_emit_checkpoint_success` / `_emit_checkpoint_failure`.
+- Added `BaseCheckPointer.bind_metrics(collector, labels)` so Consumer can inject
+  its `stream_name` label into the checkpointer's emissions at construction time.
+  Intentionally not added to the `CheckPointer` Protocol to avoid breaking static
+  type-checking for exotic user checkpointers; Consumer uses `hasattr()` to wire
+  metrics only on implementations that provide it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,27 @@
   label set unchanged (`{stream_name, shard_id}`); checkpointers used without a
   Consumer appear under a new sentinel `stream_name="<standalone>"`.
 
+### Backwards compatibility
+- **Shared checkpointer across Consumers**: reusing a single `CheckPointer`
+  instance across multiple `Consumer`s with different `stream_name` or different
+  `metrics_collector` now raises `RuntimeError` at the second Consumer's
+  construction (from `BaseCheckPointer.bind_metrics`). Idempotent rebind with
+  matching args is still a no-op. If you relied on sharing a checkpointer, give
+  each Consumer its own instance.
+- **Metric cadence in manual mode**: `consumer_checkpoint_success_total` no
+  longer ticks on every per-shard `checkpoint()` call under `auto_checkpoint=False`.
+  It stays flat between `manual_checkpoint()` flushes and spikes in bursts on
+  flush. Dashboards using `rate(consumer_checkpoint_success_total[5m])` will
+  show quiet periods followed by spikes, which is the correct signal (durable
+  writes actually happen in bursts).
+- **New sentinel label value**: checkpointers constructed without a Consumer
+  default to `stream_name="<standalone>"` until `bind_metrics` is called.
+  Dashboards filtering on specific stream names are unaffected; wildcard
+  queries will see the new value.
+
 ### Internal
-- Removed `Consumer._checkpoint_with_metrics` (private, added in v2.5.0 four days
-  prior). Callers invoke `checkpointer.checkpoint()` directly; emission now lives
+- Removed `Consumer._checkpoint_with_metrics` (private, added in v2.5.0).
+  Callers invoke `checkpointer.checkpoint()` directly; emission now lives
   on `BaseCheckPointer` via `_emit_checkpoint_success` / `_emit_checkpoint_failure`.
 - Added `BaseCheckPointer.bind_metrics(collector, labels)` so Consumer can inject
   its `stream_name` label into the checkpointer's emissions at construction time.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,22 +13,27 @@
   Consumer appear under a new sentinel `stream_name="<standalone>"`.
 
 ### Backwards compatibility
-- **Shared checkpointer across Consumers**: reusing a single `CheckPointer`
+- **Shared checkpointer across Consumers** (`BaseCheckPointer` subclasses only):
+  reusing a single `MemoryCheckPointer` / `RedisCheckPointer` / `DynamoDBCheckPointer`
   instance across multiple `Consumer`s with different `stream_name` or different
-  `metrics_collector` now raises `RuntimeError` at the second Consumer's
-  construction (from `BaseCheckPointer.bind_metrics`). Idempotent rebind with
-  matching args is still a no-op. If you relied on sharing a checkpointer, give
-  each Consumer its own instance.
+  `metrics_collector` now raises `RuntimeError` at the second Consumer's construction
+  (from `bind_metrics`). Idempotent rebind with matching args is still a no-op.
+  Custom checkpointers that conform to the `CheckPointer` Protocol without
+  implementing `bind_metrics` are unaffected (they silently opt out of checkpoint
+  metrics, same as before). If you relied on sharing a built-in checkpointer,
+  give each Consumer its own instance.
 - **Metric cadence in manual mode**: `consumer_checkpoint_success_total` no
   longer ticks on every per-shard `checkpoint()` call under `auto_checkpoint=False`.
   It stays flat between `manual_checkpoint()` flushes and spikes in bursts on
   flush. Dashboards using `rate(consumer_checkpoint_success_total[5m])` will
   show quiet periods followed by spikes, which is the correct signal (durable
   writes actually happen in bursts).
-- **New sentinel label value**: checkpointers constructed without a Consumer
-  default to `stream_name="<standalone>"` until `bind_metrics` is called.
-  Dashboards filtering on specific stream names are unaffected; wildcard
-  queries will see the new value.
+- **New sentinel label value** (`BaseCheckPointer` subclasses only): built-in
+  checkpointers constructed without a Consumer now default to
+  `stream_name="<standalone>"` until `bind_metrics` is called. Dashboards
+  filtering on specific stream names are unaffected; wildcard queries will see
+  the new value. Custom Protocol-only checkpointers emit whatever labels they
+  always did.
 
 ### Internal
 - Removed `Consumer._checkpoint_with_metrics` (private, added in v2.5.0).

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -115,14 +115,18 @@ async with Producer(stream_name="my-stream") as producer:
 | `consumer_records_received_total` | Counter | Records successfully enqueued to the consumer queue (raw Kinesis rows, pre-deaggregation). Rows dropped mid-batch by a queue timeout are not counted. | `stream_name`, `shard_id` |
 | `consumer_bytes_received_total` | Counter | Bytes of `Data` for rows counted by `consumer_records_received_total`. | `stream_name`, `shard_id` |
 | `consumer_errors_total` | Counter | Errors in `get_records`. `error_type` is `connection`, `timeout`, `unknown`, or the raw AWS error code (e.g. `ProvisionedThroughputExceededException`, `ExpiredIteratorException`, `InternalFailure`). | `stream_name`, `shard_id`, `error_type` |
-| `consumer_checkpoint_success_total` | Counter | Checkpointer backend calls that returned successfully. | `stream_name`, `shard_id` |
-| `consumer_checkpoint_failure_total` | Counter | Checkpointer backend calls that raised. | `stream_name`, `shard_id` |
+| `consumer_checkpoint_success_total` | Counter | Durable backend-persist operations that returned successfully. Under `auto_checkpoint=False`, only increments when `checkpointer.manual_checkpoint()` flushes, not on every per-shard checkpoint call (those buffer without writing). | `stream_name`, `shard_id` |
+| `consumer_checkpoint_failure_total` | Counter | Durable backend-persist operations that raised. Same manual-mode caveat as success. | `stream_name`, `shard_id` |
 | `consumer_iterator_age_milliseconds` | Gauge | `MillisBehindLatest` from the last `GetRecords` response. Only emitted when the backend populates the field. | `stream_name`, `shard_id` |
 | `consumer_queue_size` | Gauge | Consumer internal queue depth after the enqueue pass. | `stream_name` |
 | `consumer_lag_records` | Gauge | *Planned* - not currently emitted. | `stream_name`, `shard_id` |
 | `consumer_processing_time_seconds` | Histogram | *Planned* - not currently emitted. | `stream_name`, `shard_id` |
 
 `consumer_errors_total` uses raw AWS error codes rather than semantic labels. `ProvisionedThroughputExceededException` and `ExpiredIteratorException` are recovery events, not failures; alert on `connection`, `unknown`, and `InternalFailure` instead.
+
+**Checkpoint counter semantics**: `consumer_checkpoint_*` counters track the underlying backend write (Redis `SET`, DynamoDB `UpdateItem`, memory dict write), not the Consumer's per-iteration checkpoint call. Under `auto_checkpoint=False` (Redis/DynamoDB manual mode), these counters stay flat between `manual_checkpoint()` flushes and then increment in bursts when the user flushes. Dashboards using `rate(consumer_checkpoint_success_total[5m])` will show quiet periods followed by spikes, which is the correct signal: durable writes actually happen in bursts.
+
+**Standalone usage**: A checkpointer used without a Consumer (e.g. a worker orchestrating its own `manual_checkpoint()`) defaults to `stream_name="<standalone>"` until `checkpointer.bind_metrics(collector, {"stream_name": "..."})` is called. The sentinel is visible in dashboards; use it to distinguish consumer-wired emissions from direct-use ones.
 
 ### Stream Metrics
 

--- a/kinesis/checkpointers.py
+++ b/kinesis/checkpointers.py
@@ -5,7 +5,11 @@ import os
 from datetime import datetime, timezone
 from typing import Any, Dict, Optional, Protocol, Tuple, Union
 
+from .metrics import MetricsCollector, MetricType, get_metrics_collector
+
 log = logging.getLogger(__name__)
+
+STANDALONE_STREAM_LABEL = "<standalone>"
 
 
 class CheckPointer(Protocol):
@@ -72,12 +76,42 @@ class CheckPointer(Protocol):
         """
         ...
 
+    # NOTE: bind_metrics is intentionally NOT part of the Protocol. Adding it
+    # would break static type-checking for exotic user checkpointers. Consumer
+    # uses hasattr() to wire metrics only on implementations that provide it
+    # (which BaseCheckPointer and its subclasses do). Exotic checkpointers opt
+    # out of checkpoint-success/failure metrics; they can add bind_metrics if
+    # they want to participate.
+
 
 class BaseCheckPointer:
     def __init__(self, name: str = "", id: Optional[Union[str, int]] = None) -> None:
         self._id: Union[str, int] = id if id else os.getpid()
         self._name: str = name
         self._items: Dict[str, Any] = {}
+        self.metrics: MetricsCollector = get_metrics_collector()
+        self._metrics_labels: Dict[str, str] = {"stream_name": STANDALONE_STREAM_LABEL}
+        self._metrics_bound: bool = False
+
+    def bind_metrics(self, collector: MetricsCollector, labels: Dict[str, str]) -> None:
+        if self._metrics_bound:
+            if self.metrics is collector and self._metrics_labels == labels:
+                return
+            raise RuntimeError(
+                "Checkpointer already bound to a different metrics collector or labels. "
+                "Sharing a checkpointer across consumers is not supported."
+            )
+        self.metrics = collector
+        self._metrics_labels = dict(labels)
+        self._metrics_bound = True
+
+    def _emit_checkpoint_success(self, shard_id: str) -> None:
+        labels = {**self._metrics_labels, "shard_id": shard_id}
+        self.metrics.increment(MetricType.CONSUMER_CHECKPOINT_SUCCESS, 1, labels)
+
+    def _emit_checkpoint_failure(self, shard_id: str) -> None:
+        labels = {**self._metrics_labels, "shard_id": shard_id}
+        self.metrics.increment(MetricType.CONSUMER_CHECKPOINT_FAILURE, 1, labels)
 
     def get_id(self) -> Union[str, int]:
         return self._id
@@ -155,8 +189,13 @@ class MemoryCheckPointer(BaseCheckPointer):
         return True, self._items[shard_id]["sequence"]
 
     async def checkpoint(self, shard_id, sequence):
-        log.debug("{} checkpointed on {} @ {}".format(self.get_ref(), shard_id, sequence))
-        self._items[shard_id]["sequence"] = sequence
+        try:
+            log.debug("{} checkpointed on {} @ {}".format(self.get_ref(), shard_id, sequence))
+            self._items[shard_id]["sequence"] = sequence
+        except Exception:
+            self._emit_checkpoint_failure(shard_id)
+            raise
+        self._emit_checkpoint_success(shard_id)
 
 
 class RedisCheckPointer(BaseHeartbeatCheckPointer):
@@ -224,24 +263,30 @@ class RedisCheckPointer(BaseHeartbeatCheckPointer):
             await self._checkpoint(shard_id, sequence)
 
     async def _checkpoint(self, shard_id, sequence):
+        try:
+            key = self.get_key(shard_id)
 
-        key = self.get_key(shard_id)
+            val = {"ref": self.get_ref(), "ts": self.get_ts(), "sequence": sequence}
 
-        val = {"ref": self.get_ref(), "ts": self.get_ts(), "sequence": sequence}
+            previous_val = await self.client.getset(key, json.dumps(val))
+            previous_val = json.loads(previous_val) if previous_val else None
 
-        previous_val = await self.client.getset(key, json.dumps(val))
-        previous_val = json.loads(previous_val) if previous_val else None
+            if not previous_val:
+                raise NotImplementedError(
+                    "{} checkpointed on {} but key did not exist?".format(self.get_ref(), shard_id)
+                )
 
-        if not previous_val:
-            raise NotImplementedError("{} checkpointed on {} but key did not exist?".format(self.get_ref(), shard_id))
+            if previous_val["ref"] != self.get_ref():
+                raise NotImplementedError(
+                    "{} checkpointed on {} but ref is different {}".format(self.get_ref(), shard_id, val["ref"])
+                )
 
-        if previous_val["ref"] != self.get_ref():
-            raise NotImplementedError(
-                "{} checkpointed on {} but ref is different {}".format(self.get_ref(), shard_id, val["ref"])
-            )
-
-        log.debug("{} checkpointed on {}@{}".format(self.get_ref(), shard_id, sequence))
-        self._items[shard_id] = sequence
+            log.debug("{} checkpointed on {}@{}".format(self.get_ref(), shard_id, sequence))
+            self._items[shard_id] = sequence
+        except Exception:
+            self._emit_checkpoint_failure(shard_id)
+            raise
+        self._emit_checkpoint_success(shard_id)
 
     async def deallocate(self, shard_id):
 

--- a/kinesis/checkpointers.py
+++ b/kinesis/checkpointers.py
@@ -19,6 +19,14 @@ class CheckPointer(Protocol):
     can resume from the correct position after a restart. They also provide
     shard-level locking so that multiple consumers don't process the same
     shard concurrently.
+
+    Metrics opt-in (optional): implementations that want to participate in
+    ``consumer_checkpoint_success_total`` / ``consumer_checkpoint_failure_total``
+    should also implement ``bind_metrics(collector, labels)`` and emit on their
+    real backend-write path (see ``BaseCheckPointer`` for the reference pattern).
+    The Consumer detects the method via ``hasattr`` and wires it at construction;
+    implementations without ``bind_metrics`` still work but produce no checkpoint
+    metrics.
     """
 
     async def allocate(self, shard_id: str) -> Tuple[bool, Optional[str]]:
@@ -94,6 +102,13 @@ class BaseCheckPointer:
         self._metrics_bound: bool = False
 
     def bind_metrics(self, collector: MetricsCollector, labels: Dict[str, str]) -> None:
+        # Fail fast: checkpoint metrics register labelnames=["stream_name", "shard_id"]
+        # (see PrometheusMetricsCollector). shard_id is added at emit time, so the
+        # caller must supply stream_name here. Without this check, a malformed bind
+        # would only surface later when Prometheus rejects the labelset at first emit,
+        # far from the wiring site.
+        if "stream_name" not in labels:
+            raise ValueError("bind_metrics requires a 'stream_name' label " f"(got keys: {sorted(labels.keys())!r})")
         if self._metrics_bound:
             if self.metrics is collector and self._metrics_labels == labels:
                 return

--- a/kinesis/consumer.py
+++ b/kinesis/consumer.py
@@ -136,6 +136,11 @@ class Consumer(Base):
         # Metrics collector
         self.metrics = metrics_collector if metrics_collector else get_metrics_collector()
 
+        # Wire checkpointer to emit consumer_checkpoint_* counters with our stream_name.
+        # Optional: exotic user checkpointers conforming to the Protocol may not implement it.
+        if hasattr(self.checkpointer, "bind_metrics"):
+            self.checkpointer.bind_metrics(self.metrics, {"stream_name": self.stream_name})
+
     def __aiter__(self) -> AsyncIterator[Any]:
         return self
 
@@ -419,7 +424,7 @@ class Consumer(Base):
                             # Flush interval-buffered checkpoint for this shard
                             if shard_id in self._pending_checkpoints:
                                 seq = self._pending_checkpoints[shard_id]
-                                await self._checkpoint_with_metrics(shard_id, seq)
+                                await self.checkpointer.checkpoint(shard_id, seq)
                                 if self._pending_checkpoints.get(shard_id) == seq:
                                     del self._pending_checkpoints[shard_id]
 
@@ -916,21 +921,11 @@ class Consumer(Base):
         """Non-blocking check whether consumer has obtained shard iterators."""
         return self._ready.is_set()
 
-    async def _checkpoint_with_metrics(self, shard_id: str, sequence: str) -> None:
-        """Call checkpointer.checkpoint and emit success/failure metrics."""
-        cp_labels = {"stream_name": self.stream_name, "shard_id": shard_id}
-        try:
-            await self.checkpointer.checkpoint(shard_id, sequence)
-            self.metrics.increment(MetricType.CONSUMER_CHECKPOINT_SUCCESS, 1, cp_labels)
-        except Exception:
-            self.metrics.increment(MetricType.CONSUMER_CHECKPOINT_FAILURE, 1, cp_labels)
-            raise
-
     async def _maybe_checkpoint(self, shard_id: str, sequence: str):
         """Commit a checkpoint, either immediately or via interval buffer."""
         if self.checkpoint_interval is None:
             # No debouncing — checkpoint immediately
-            await self._checkpoint_with_metrics(shard_id, sequence)
+            await self.checkpointer.checkpoint(shard_id, sequence)
             return
 
         # Buffer for background flush
@@ -965,7 +960,7 @@ class Consumer(Base):
             seq = self._pending_checkpoints.get(shard_id)
             if seq is None:
                 continue
-            await self._checkpoint_with_metrics(shard_id, seq)
+            await self.checkpointer.checkpoint(shard_id, seq)
             # Only delete if the value hasn't been superseded during the await
             if self._pending_checkpoints.get(shard_id) == seq:
                 del self._pending_checkpoints[shard_id]

--- a/kinesis/dynamodb.py
+++ b/kinesis/dynamodb.py
@@ -221,48 +221,52 @@ class DynamoDBCheckPointer(BaseHeartbeatCheckPointer):
 
     async def _checkpoint(self, shard_id: str, sequence: str) -> None:
         """Internal checkpoint implementation."""
-        try:
-            if not self._initialized:
-                await self._initialize()
+        if not self._initialized:
+            await self._initialize()
 
-            key = self.get_key(shard_id)
+        key = self.get_key(shard_id)
 
-            async with self._session.resource("dynamodb", region_name=self.region_name) as dynamodb:
-                table = await dynamodb.Table(self.table_name)
+        async with self._session.resource("dynamodb", region_name=self.region_name) as dynamodb:
+            table = await dynamodb.Table(self.table_name)
 
-                try:
-                    # Update sequence number only if we own the shard
-                    await table.update_item(
-                        Key={"shard_id": key},
-                        UpdateExpression="SET #seq = :seq, #ts = :ts, #ttl = :ttl",
-                        ExpressionAttributeNames={
-                            "#seq": "sequence",
-                            "#ts": "ts",
-                            "#ttl": "ttl",
-                            "#ref": "ref",
-                        },
-                        ExpressionAttributeValues={
-                            ":seq": sequence,
-                            ":ts": self.get_ts(),
-                            ":ttl": self.get_ttl(),
-                            ":expected_ref": self.get_ref(),
-                        },
-                        ConditionExpression="#ref = :expected_ref",
-                        ReturnValues="ALL_NEW",
-                    )
+            # Emission is scoped to the update_item call only. Init errors and
+            # resource context enter/exit failures (e.g. aiobotocore teardown
+            # AssertionError documented in base.py) are not counted as checkpoint
+            # failures: init is an app-wide fault, and teardown happens after a
+            # successful write so the durable state is already persisted.
+            try:
+                # Update sequence number only if we own the shard
+                await table.update_item(
+                    Key={"shard_id": key},
+                    UpdateExpression="SET #seq = :seq, #ts = :ts, #ttl = :ttl",
+                    ExpressionAttributeNames={
+                        "#seq": "sequence",
+                        "#ts": "ts",
+                        "#ttl": "ttl",
+                        "#ref": "ref",
+                    },
+                    ExpressionAttributeValues={
+                        ":seq": sequence,
+                        ":ts": self.get_ts(),
+                        ":ttl": self.get_ttl(),
+                        ":expected_ref": self.get_ref(),
+                    },
+                    ConditionExpression="#ref = :expected_ref",
+                    ReturnValues="ALL_NEW",
+                )
+            except ClientError as e:
+                self._emit_checkpoint_failure(shard_id)
+                if e.response["Error"]["Code"] == "ConditionalCheckFailedException":
+                    raise Exception(f"{self.get_ref()} tried to checkpoint {shard_id} but does not own it") from e
+                else:
+                    raise
+            except Exception:
+                self._emit_checkpoint_failure(shard_id)
+                raise
 
-                    log.debug(f"{self.get_ref()} checkpointed on {shard_id}@{sequence}")
-                    self._items[shard_id] = sequence
-
-                except ClientError as e:
-                    if e.response["Error"]["Code"] == "ConditionalCheckFailedException":
-                        raise Exception(f"{self.get_ref()} tried to checkpoint {shard_id} but does not own it") from e
-                    else:
-                        raise
-        except Exception:
-            self._emit_checkpoint_failure(shard_id)
-            raise
-        self._emit_checkpoint_success(shard_id)
+            log.debug(f"{self.get_ref()} checkpointed on {shard_id}@{sequence}")
+            self._items[shard_id] = sequence
+            self._emit_checkpoint_success(shard_id)
 
     async def deallocate(self, shard_id: str) -> None:
         """Deallocate a shard."""

--- a/kinesis/dynamodb.py
+++ b/kinesis/dynamodb.py
@@ -221,43 +221,50 @@ class DynamoDBCheckPointer(BaseHeartbeatCheckPointer):
 
     async def _checkpoint(self, shard_id: str, sequence: str) -> None:
         """Internal checkpoint implementation."""
-        if not self._initialized:
-            await self._initialize()
+        try:
+            if not self._initialized:
+                await self._initialize()
 
-        key = self.get_key(shard_id)
+            key = self.get_key(shard_id)
 
-        async with self._session.resource("dynamodb", region_name=self.region_name) as dynamodb:
-            table = await dynamodb.Table(self.table_name)
+            async with self._session.resource("dynamodb", region_name=self.region_name) as dynamodb:
+                table = await dynamodb.Table(self.table_name)
 
-            try:
-                # Update sequence number only if we own the shard
-                await table.update_item(
-                    Key={"shard_id": key},
-                    UpdateExpression="SET #seq = :seq, #ts = :ts, #ttl = :ttl",
-                    ExpressionAttributeNames={
-                        "#seq": "sequence",
-                        "#ts": "ts",
-                        "#ttl": "ttl",
-                        "#ref": "ref",
-                    },
-                    ExpressionAttributeValues={
-                        ":seq": sequence,
-                        ":ts": self.get_ts(),
-                        ":ttl": self.get_ttl(),
-                        ":expected_ref": self.get_ref(),
-                    },
-                    ConditionExpression="#ref = :expected_ref",
-                    ReturnValues="ALL_NEW",
-                )
+                try:
+                    # Update sequence number only if we own the shard
+                    await table.update_item(
+                        Key={"shard_id": key},
+                        UpdateExpression="SET #seq = :seq, #ts = :ts, #ttl = :ttl",
+                        ExpressionAttributeNames={
+                            "#seq": "sequence",
+                            "#ts": "ts",
+                            "#ttl": "ttl",
+                            "#ref": "ref",
+                        },
+                        ExpressionAttributeValues={
+                            ":seq": sequence,
+                            ":ts": self.get_ts(),
+                            ":ttl": self.get_ttl(),
+                            ":expected_ref": self.get_ref(),
+                        },
+                        ConditionExpression="#ref = :expected_ref",
+                        ReturnValues="ALL_NEW",
+                    )
 
-                log.debug(f"{self.get_ref()} checkpointed on {shard_id}@{sequence}")
-                self._items[shard_id] = sequence
+                    log.debug(f"{self.get_ref()} checkpointed on {shard_id}@{sequence}")
+                    self._items[shard_id] = sequence
 
-            except ClientError as e:
-                if e.response["Error"]["Code"] == "ConditionalCheckFailedException":
-                    raise Exception(f"{self.get_ref()} tried to checkpoint {shard_id} but does not own it") from e
-                else:
-                    raise
+                except ClientError as e:
+                    if e.response["Error"]["Code"] == "ConditionalCheckFailedException":
+                        raise Exception(
+                            f"{self.get_ref()} tried to checkpoint {shard_id} but does not own it"
+                        ) from e
+                    else:
+                        raise
+        except Exception:
+            self._emit_checkpoint_failure(shard_id)
+            raise
+        self._emit_checkpoint_success(shard_id)
 
     async def deallocate(self, shard_id: str) -> None:
         """Deallocate a shard."""

--- a/kinesis/dynamodb.py
+++ b/kinesis/dynamodb.py
@@ -256,9 +256,7 @@ class DynamoDBCheckPointer(BaseHeartbeatCheckPointer):
 
                 except ClientError as e:
                     if e.response["Error"]["Code"] == "ConditionalCheckFailedException":
-                        raise Exception(
-                            f"{self.get_ref()} tried to checkpoint {shard_id} but does not own it"
-                        ) from e
+                        raise Exception(f"{self.get_ref()} tried to checkpoint {shard_id} but does not own it") from e
                     else:
                         raise
         except Exception:

--- a/kinesis/testing.py
+++ b/kinesis/testing.py
@@ -300,9 +300,12 @@ class MockConsumer:
 
         self.stream_name = stream_name
         self.processor = processor if processor else JsonProcessor()
-        # Stored for parity with Consumer; MockConsumer does not emit metrics itself.
+        # Stored for parity with Consumer; MockConsumer does not emit metrics itself,
+        # but a bound checkpointer (e.g. MemoryCheckPointer) emits via bind_metrics.
         self.metrics = metrics_collector if metrics_collector else get_metrics_collector()
         self.checkpointer = checkpointer if checkpointer else MemoryCheckPointer()
+        if hasattr(self.checkpointer, "bind_metrics"):
+            self.checkpointer.bind_metrics(self.metrics, {"stream_name": self.stream_name})
         self.iterator_type = iterator_type
         self._create_stream = create_stream
         self._create_stream_shards = create_stream_shards

--- a/tests/test_dynamodb_checkpointer.py
+++ b/tests/test_dynamodb_checkpointer.py
@@ -308,14 +308,8 @@ class TestDynamoDBCheckPointer:
         await checkpointer.manual_checkpoint()
 
         assert mock_dynamodb["table"].update_item.called
-        assert (
-            collector.counters["consumer_checkpoint_success_total{shard_id=shard-001,stream_name=test-stream}"]
-            == 1
-        )
-        assert (
-            collector.counters["consumer_checkpoint_success_total{shard_id=shard-002,stream_name=test-stream}"]
-            == 1
-        )
+        assert collector.counters["consumer_checkpoint_success_total{shard_id=shard-001,stream_name=test-stream}"] == 1
+        assert collector.counters["consumer_checkpoint_success_total{shard_id=shard-002,stream_name=test-stream}"] == 1
 
     @pytest.mark.asyncio
     async def test_checkpoint_failure_emits_metric(self, mock_dynamodb):
@@ -334,10 +328,7 @@ class TestDynamoDBCheckPointer:
         with pytest.raises(Exception, match="does not own it"):
             await checkpointer._checkpoint("shard-001", "seq-123")
 
-        assert (
-            collector.counters["consumer_checkpoint_failure_total{shard_id=shard-001,stream_name=test-stream}"]
-            == 1
-        )
+        assert collector.counters["consumer_checkpoint_failure_total{shard_id=shard-001,stream_name=test-stream}"] == 1
         assert not any(k.startswith("consumer_checkpoint_success_") for k in collector.counters)
 
     @pytest.mark.asyncio

--- a/tests/test_dynamodb_checkpointer.py
+++ b/tests/test_dynamodb_checkpointer.py
@@ -288,20 +288,57 @@ class TestDynamoDBCheckPointer:
 
     @pytest.mark.asyncio
     async def test_manual_checkpoint(self, mock_dynamodb):
-        """Test manual checkpointing mode."""
+        """Test manual checkpointing mode + metrics emission on backend write."""
+        from kinesis import InMemoryMetricsCollector
+
+        collector = InMemoryMetricsCollector()
         checkpointer = DynamoDBCheckPointer("test-app", auto_checkpoint=False)
+        checkpointer.bind_metrics(collector, {"stream_name": "test-stream"})
         await checkpointer._initialize()
 
-        # Manual checkpoint should not call DynamoDB immediately
+        # Manual mode: checkpoint() buffers, does NOT call DynamoDB or emit metrics.
         await checkpointer.checkpoint("shard-001", "seq-123")
+        await checkpointer.checkpoint("shard-002", "seq-456")
 
         assert not mock_dynamodb["table"].update_item.called
-        assert checkpointer._manual_checkpoints["shard-001"] == "seq-123"
+        assert checkpointer._manual_checkpoints == {"shard-001": "seq-123", "shard-002": "seq-456"}
+        assert not any(k.startswith("consumer_checkpoint_") for k in collector.counters)
 
-        # Manual checkpoint should update DynamoDB
+        # manual_checkpoint() drives real backend writes and emits one success per shard.
         await checkpointer.manual_checkpoint()
 
         assert mock_dynamodb["table"].update_item.called
+        assert (
+            collector.counters["consumer_checkpoint_success_total{shard_id=shard-001,stream_name=test-stream}"]
+            == 1
+        )
+        assert (
+            collector.counters["consumer_checkpoint_success_total{shard_id=shard-002,stream_name=test-stream}"]
+            == 1
+        )
+
+    @pytest.mark.asyncio
+    async def test_checkpoint_failure_emits_metric(self, mock_dynamodb):
+        """ConditionalCheckFailedException (lost ownership) counts as a failure."""
+        from kinesis import InMemoryMetricsCollector
+
+        collector = InMemoryMetricsCollector()
+        checkpointer = DynamoDBCheckPointer("test-app")
+        checkpointer.bind_metrics(collector, {"stream_name": "test-stream"})
+        await checkpointer._initialize()
+
+        mock_dynamodb["table"].update_item.side_effect = ClientError(
+            {"Error": {"Code": "ConditionalCheckFailedException"}}, "UpdateItem"
+        )
+
+        with pytest.raises(Exception, match="does not own it"):
+            await checkpointer._checkpoint("shard-001", "seq-123")
+
+        assert (
+            collector.counters["consumer_checkpoint_failure_total{shard_id=shard-001,stream_name=test-stream}"]
+            == 1
+        )
+        assert not any(k.startswith("consumer_checkpoint_success_") for k in collector.counters)
 
     @pytest.mark.asyncio
     async def test_close(self, mock_dynamodb):

--- a/tests/test_metrics_unit.py
+++ b/tests/test_metrics_unit.py
@@ -467,12 +467,36 @@ class TestConsumerGetRecordsErrors:
         assert collector.counters[key] == 1
 
 
+async def _make_redis_cp(auto_checkpoint=True):
+    """Construct a RedisCheckPointer with a mocked client and a cancelled heartbeat task.
+
+    Returns the checkpointer with `self.client` replaced by an AsyncMock. Callers
+    configure the mock's return/side-effect as needed and must `await cp.close()`
+    (or rely on the try/finally) to cancel the heartbeat.
+    """
+    from kinesis.checkpointers import RedisCheckPointer
+
+    cp = RedisCheckPointer("test", auto_checkpoint=auto_checkpoint, heartbeat_frequency=3600)
+    cp.heartbeat_task.cancel()
+    try:
+        await cp.heartbeat_task
+    except asyncio.CancelledError:
+        pass
+    cp.client = AsyncMock()
+    return cp
+
+
 class TestConsumerCheckpointMetrics:
+    """Emission now happens in the checkpointer's backend-write path. These tests
+    exercise the real write paths of MemoryCheckPointer (success) and
+    RedisCheckPointer (failure), not the removed Consumer wrapper."""
+
     @pytest.mark.asyncio
     async def test_maybe_checkpoint_success(self, mock_consumer):
         collector = InMemoryMetricsCollector()
         consumer = mock_consumer(metrics_collector=collector)
-        consumer.checkpointer = AsyncMock()
+        # Default MemoryCheckPointer is bound to the consumer's collector via __init__.
+        await consumer.checkpointer.allocate("shard-0")
 
         await consumer._maybe_checkpoint("shard-0", "seq-1")
 
@@ -481,14 +505,18 @@ class TestConsumerCheckpointMetrics:
         assert f"consumer_checkpoint_failure_total{{{_shard_labels('shard-0')}}}" not in collector.counters
 
     @pytest.mark.asyncio
-    async def test_maybe_checkpoint_failure(self, mock_consumer):
+    async def test_checkpoint_failure_emits_on_backend_raise(self):
+        """Exercise RedisCheckPointer._checkpoint try/except with a raising client."""
         collector = InMemoryMetricsCollector()
-        consumer = mock_consumer(metrics_collector=collector)
-        consumer.checkpointer = AsyncMock()
-        consumer.checkpointer.checkpoint.side_effect = RuntimeError("backend down")
+        cp = await _make_redis_cp()
+        cp.bind_metrics(collector, {"stream_name": "test-stream"})
+        cp.client.getset = AsyncMock(side_effect=RuntimeError("backend down"))
 
-        with pytest.raises(RuntimeError):
-            await consumer._maybe_checkpoint("shard-0", "seq-1")
+        try:
+            with pytest.raises(RuntimeError):
+                await cp._checkpoint("shard-0", "seq-1")
+        finally:
+            await cp.close()
 
         key = f"consumer_checkpoint_failure_total{{{_shard_labels('shard-0')}}}"
         assert collector.counters[key] == 1
@@ -498,13 +526,129 @@ class TestConsumerCheckpointMetrics:
     async def test_flush_pending_checkpoints_success(self, mock_consumer):
         collector = InMemoryMetricsCollector()
         consumer = mock_consumer(metrics_collector=collector)
-        consumer.checkpointer = AsyncMock()
+        await consumer.checkpointer.allocate("shard-0")
+        await consumer.checkpointer.allocate("shard-1")
         consumer._pending_checkpoints = {"shard-0": "seq-1", "shard-1": "seq-9"}
 
         await consumer._flush_pending_checkpoints()
 
         assert collector.counters[f"consumer_checkpoint_success_total{{{_shard_labels('shard-0')}}}"] == 1
         assert collector.counters[f"consumer_checkpoint_success_total{{{_shard_labels('shard-1')}}}"] == 1
+
+    @pytest.mark.asyncio
+    async def test_checkpoint_metrics_skipped_in_manual_mode(self):
+        """Under auto_checkpoint=False, Redis checkpoint() buffers without emitting."""
+        collector = InMemoryMetricsCollector()
+        cp = await _make_redis_cp(auto_checkpoint=False)
+        cp.bind_metrics(collector, {"stream_name": "test-stream"})
+
+        try:
+            await cp.checkpoint("shard-0", "seq-1")
+        finally:
+            await cp.close()
+
+        # No counters at all: neither success nor failure
+        assert not any(key.startswith("consumer_checkpoint_") for key in collector.counters)
+        assert cp._manual_checkpoints == {"shard-0": "seq-1"}
+
+    @pytest.mark.asyncio
+    async def test_manual_checkpoint_flush_emits_per_shard(self):
+        """manual_checkpoint() flush hits the real backend path, so emits one per shard."""
+        collector = InMemoryMetricsCollector()
+        cp = await _make_redis_cp(auto_checkpoint=False)
+        cp.bind_metrics(collector, {"stream_name": "test-stream"})
+        cp.client.getset = AsyncMock(return_value=None)  # triggers NotImplementedError
+
+        try:
+            await cp.checkpoint("shard-0", "seq-1")
+            await cp.checkpoint("shard-1", "seq-9")
+            assert not any(key.startswith("consumer_checkpoint_") for key in collector.counters)
+
+            # Flush: client.getset returns None -> _checkpoint raises -> failure counter
+            # (We don't need happy-path Redis semantics here; we're verifying the emit
+            # wiring covers the real path, which is what matters.)
+            with pytest.raises(NotImplementedError):
+                await cp.manual_checkpoint()
+        finally:
+            await cp.close()
+
+        # At least one shard's failure was emitted before the raise aborted the loop.
+        # This also documents the pre-existing lose-on-failure bug: the loop
+        # stops on first raise so the second shard's emit never happens.
+        failure_key_0 = f"consumer_checkpoint_failure_total{{{_shard_labels('shard-0')}}}"
+        assert collector.counters.get(failure_key_0) == 1
+
+    @pytest.mark.asyncio
+    async def test_manual_checkpoint_flush_success_path_emits_per_shard(self):
+        """Happy-path manual flush on MemoryCheckPointer-style emission (direct exercise)."""
+        collector = InMemoryMetricsCollector()
+        cp = MemoryCheckPointer("test")
+        cp.bind_metrics(collector, {"stream_name": "test-stream"})
+        await cp.allocate("shard-0")
+        await cp.allocate("shard-1")
+
+        await cp.checkpoint("shard-0", "seq-1")
+        await cp.checkpoint("shard-1", "seq-9")
+
+        assert collector.counters[f"consumer_checkpoint_success_total{{{_shard_labels('shard-0')}}}"] == 1
+        assert collector.counters[f"consumer_checkpoint_success_total{{{_shard_labels('shard-1')}}}"] == 1
+
+    @pytest.mark.asyncio
+    async def test_checkpointer_without_consumer_uses_standalone_label(self):
+        """Checkpointer used directly (no Consumer) defaults to stream_name=<standalone>."""
+        collector = InMemoryMetricsCollector()
+        from kinesis.metrics import get_metrics_collector as _get
+
+        # Temporarily make <collector> the global so default __init__ picks it up.
+        previous = _get()
+        set_metrics_collector(collector)
+        try:
+            cp = MemoryCheckPointer("test")
+            await cp.allocate("shard-0")
+            await cp.checkpoint("shard-0", "seq-1")
+        finally:
+            set_metrics_collector(previous)
+
+        key = f"consumer_checkpoint_success_total{{shard_id=shard-0,stream_name=<standalone>}}"
+        assert collector.counters[key] == 1
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_does_not_emit_checkpoint_counters(self):
+        """Regression guard: heartbeat must not route through _checkpoint."""
+        collector = InMemoryMetricsCollector()
+        cp = await _make_redis_cp()
+        cp.bind_metrics(collector, {"stream_name": "test-stream"})
+        cp._items = {"shard-0": "seq-1"}
+        cp.client.set = AsyncMock(return_value=True)
+
+        # Simulate one heartbeat tick synchronously (without the sleep loop)
+        key = cp.get_key("shard-0")
+        val = {"ref": cp.get_ref(), "ts": cp.get_ts(), "sequence": "seq-1"}
+        await cp.do_heartbeat(key, val)
+
+        try:
+            pass
+        finally:
+            await cp.close()
+
+        assert not any(k.startswith("consumer_checkpoint_") for k in collector.counters)
+
+    @pytest.mark.asyncio
+    async def test_bind_metrics_rebind_with_same_args_is_noop(self):
+        cp = MemoryCheckPointer("test")
+        collector = InMemoryMetricsCollector()
+        labels = {"stream_name": "test-stream"}
+        cp.bind_metrics(collector, labels)
+        cp.bind_metrics(collector, labels)  # idempotent: must not raise
+
+    @pytest.mark.asyncio
+    async def test_bind_metrics_rebind_with_different_collector_raises(self):
+        cp = MemoryCheckPointer("test")
+        cp.bind_metrics(InMemoryMetricsCollector(), {"stream_name": "a"})
+        with pytest.raises(RuntimeError, match="already bound"):
+            cp.bind_metrics(InMemoryMetricsCollector(), {"stream_name": "a"})
+        with pytest.raises(RuntimeError, match="already bound"):
+            cp.bind_metrics(InMemoryMetricsCollector(), {"stream_name": "b"})
 
 
 class TestStreamMetrics:

--- a/tests/test_metrics_unit.py
+++ b/tests/test_metrics_unit.py
@@ -659,6 +659,19 @@ class TestConsumerCheckpointMetrics:
             cp.bind_metrics(InMemoryMetricsCollector(), {"shard_id": "shard-0"})
 
     @pytest.mark.asyncio
+    async def test_bind_metrics_missing_stream_name_raises_before_idempotent_rebind(self):
+        """Regression guard: the stream_name check must run before the
+        _metrics_bound short-circuit, so a malformed rebind can't slip past
+        the guard via the idempotent-same-args path."""
+        cp = MemoryCheckPointer("test")
+        collector = InMemoryMetricsCollector()
+        cp.bind_metrics(collector, {"stream_name": "test-stream"})  # first bind ok
+        with pytest.raises(ValueError, match="stream_name"):
+            cp.bind_metrics(collector, {})
+        with pytest.raises(ValueError, match="stream_name"):
+            cp.bind_metrics(collector, {"shard_id": "shard-0"})
+
+    @pytest.mark.asyncio
     async def test_prometheus_checkpoint_label_roundtrip(self):
         """End-to-end label-shape check: bind → emit → PrometheusCounter.labels()
         must succeed for both a real stream_name and the standalone sentinel.

--- a/tests/test_metrics_unit.py
+++ b/tests/test_metrics_unit.py
@@ -609,7 +609,7 @@ class TestConsumerCheckpointMetrics:
         finally:
             set_metrics_collector(previous)
 
-        key = f"consumer_checkpoint_success_total{{shard_id=shard-0,stream_name=<standalone>}}"
+        key = "consumer_checkpoint_success_total{shard_id=shard-0,stream_name=<standalone>}"
         assert collector.counters[key] == 1
 
     @pytest.mark.asyncio
@@ -649,6 +649,60 @@ class TestConsumerCheckpointMetrics:
             cp.bind_metrics(InMemoryMetricsCollector(), {"stream_name": "a"})
         with pytest.raises(RuntimeError, match="already bound"):
             cp.bind_metrics(InMemoryMetricsCollector(), {"stream_name": "b"})
+
+    @pytest.mark.asyncio
+    async def test_bind_metrics_without_stream_name_raises(self):
+        cp = MemoryCheckPointer("test")
+        with pytest.raises(ValueError, match="stream_name"):
+            cp.bind_metrics(InMemoryMetricsCollector(), {})
+        with pytest.raises(ValueError, match="stream_name"):
+            cp.bind_metrics(InMemoryMetricsCollector(), {"shard_id": "shard-0"})
+
+    @pytest.mark.asyncio
+    async def test_prometheus_checkpoint_label_roundtrip(self):
+        """End-to-end label-shape check: bind → emit → PrometheusCounter.labels()
+        must succeed for both a real stream_name and the standalone sentinel.
+
+        Regression guard: Prometheus registers labelnames=["stream_name","shard_id"]
+        (see kinesis/prometheus.py). If the checkpointer ever omits a label or adds
+        an unexpected one at emit time, prometheus_client raises and the test fails.
+        """
+        prometheus_client = pytest.importorskip("prometheus_client")
+        from kinesis import PrometheusMetricsCollector
+
+        registry = prometheus_client.CollectorRegistry()
+        collector = PrometheusMetricsCollector(registry=registry)
+
+        # Case 1: Consumer-wired stream label
+        cp1 = MemoryCheckPointer("test-wired")
+        cp1.bind_metrics(collector, {"stream_name": "my-stream"})
+        await cp1.allocate("shard-0")
+        await cp1.checkpoint("shard-0", "seq-1")
+
+        # Case 2: Standalone sentinel (no bind)
+        from kinesis.checkpointers import STANDALONE_STREAM_LABEL
+
+        previous = get_metrics_collector()
+        set_metrics_collector(collector)
+        try:
+            cp2 = MemoryCheckPointer("test-standalone")
+            await cp2.allocate("shard-1")
+            await cp2.checkpoint("shard-1", "seq-2")
+        finally:
+            set_metrics_collector(previous)
+
+        # Both label-shapes must be retrievable from the registry — proves
+        # prometheus_client accepted them without label-mismatch errors.
+        wired = registry.get_sample_value(
+            "async_kinesis_consumer_checkpoint_success_total",
+            {"stream_name": "my-stream", "shard_id": "shard-0"},
+        )
+        standalone = registry.get_sample_value(
+            "async_kinesis_consumer_checkpoint_success_total",
+            {"stream_name": STANDALONE_STREAM_LABEL, "shard_id": "shard-1"},
+        )
+        assert wired == 1.0
+        assert standalone == 1.0
 
 
 class TestStreamMetrics:


### PR DESCRIPTION
## Summary

Fixes [#73](https://github.com/hampsterx/async-kinesis/issues/73) (akursar): `consumer_checkpoint_success_total` was incrementing every consumer-side `checkpoint()` call, including the Redis/DynamoDB `auto_checkpoint=False` manual-mode path where no backend write happens. Operators saw a healthy checkpoint rate while durable writes were deferred. Simultaneously, `manual_checkpoint()` drove real writes but emitted nothing, because the Consumer wrapper was not in the call stack.

Emission now lives in each checkpointer's real write path:

- `BaseCheckPointer` gains `bind_metrics(collector, labels)` plus `_emit_checkpoint_success` / `_emit_checkpoint_failure` helpers.
- `MemoryCheckPointer.checkpoint`, `RedisCheckPointer._checkpoint`, and `DynamoDBCheckPointer._checkpoint` emit on normal return / raise. The DynamoDB outer try includes the `async with resource` context, so connection-level errors also count. `ConditionalCheckFailedException` (lost ownership) counts as a failure.
- `Consumer` injects its `stream_name` label via `bind_metrics` behind a `hasattr` guard. Checkpointers used without a Consumer default to `stream_name="<standalone>"` so dashboards filtering `stream_name=~".+"` still see them.
- `Consumer._checkpoint_with_metrics` (private, added in v2.5.0) removed; the three callers invoke `checkpointer.checkpoint(...)` directly.

## Backwards compatibility

- **Public API unchanged**: `Consumer` constructor signature, `CheckPointer` Protocol, metric names, and label set (`{stream_name, shard_id}`) all unchanged.
- **Metric value will change in manual mode**: under `auto_checkpoint=False`, `consumer_checkpoint_success_total` was previously ticking on every per-shard `checkpoint()` call. It now stays flat between `manual_checkpoint()` flushes and increments in bursts on flush (which is the correct signal: durable writes actually happen in bursts). Dashboards using `rate(consumer_checkpoint_success_total[5m])` will show quiet periods followed by spikes.
- **New sentinel label value**: checkpointers constructed without a Consumer default to `stream_name="<standalone>"` until `bind_metrics` is called. Dashboards filtering on specific stream names are unaffected; wildcard queries will see the new value.
- **Exotic user checkpointers**: `bind_metrics` is deliberately kept off the `CheckPointer` Protocol to avoid breaking static type-checking. Custom checkpointers that implement the Protocol without subclassing `BaseCheckPointer` silently opt out of checkpoint-success/failure metrics (unchanged backend behaviour, just no counter). They can adopt `bind_metrics` if they want to participate.
- **Internal removal**: `Consumer._checkpoint_with_metrics` was added in v2.5.0 four days ago and is private. Anyone who subclassed Consumer and called it directly needs to switch to `checkpointer.checkpoint(...)`.

## Test plan

- [x] 10 tests in `TestConsumerCheckpointMetrics` (up from 3): memory success, Redis failure hits real `_checkpoint` try/except, manual-mode no-emit, manual flush emits per shard, standalone label, heartbeat regression guard, bind_metrics idempotent-rebind + different-collector-raises.
- [x] DynamoDB: extended `test_manual_checkpoint` (no emit during buffer, one emit per shard on flush), new `test_checkpoint_failure_emits_metric` exercising `ConditionalCheckFailedException` → failure counter.
- [x] Full non-dynamodb suite: 221 passed, 7 skipped.
- [x] DynamoDB subset: 18 passed.
- [x] Prometheus smoke test: both `stream_name="my-stream"` and `stream_name="<standalone>"` round-trip through `PrometheusMetricsCollector` without label-mismatch errors.
- [x] External review (Codex + Gemini, `focused`): Protocol-extension concern raised, fix applied (kept `bind_metrics` off the Protocol).

## Follow-up

- Pre-existing `manual_checkpoint()` lose-on-failure (clears buffer before flush loop) is now observable via `consumer_checkpoint_failure_total` but not fixed here. Filed as #76.

Closes #73 once released.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Checkpoint metrics now reflect durable backend persist operations; in manual mode counters remain flat during buffering and spike when manual flushes occur.
  * Reusing a bound checkpointer with differing metric bindings now raises on second bind to prevent silent mislabeling.
  * Standalone checkpointers default to stream_name="<standalone>" until bound.

* **Documentation**
  * Clarified metrics semantics, dashboard/query guidance, and standalone-label behavior.

* **Tests**
  * Added unit tests covering metric emission, manual-flush behavior, binding edge cases, and failure paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->