### PR TITLE
fix(checkpointer): retain buffered entries when manual_checkpoint() raises

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 ## Unreleased
 
 ### Fixed
+- `RedisCheckPointer.manual_checkpoint()` and `DynamoDBCheckPointer.manual_checkpoint()`
+  no longer drop buffered checkpoints on a mid-loop exception. Previously, both
+  cleared `_manual_checkpoints` before iterating, so if the backend raised for
+  shard N, the entries for shards N+1..end were evicted and never retried.
+  Shards are now popped individually after a successful backend write, so a
+  raise leaves the unflushed remainder buffered for the next flush. The shard
+  that tripped also stays buffered (it was not successfully persisted), so
+  callers that retry will re-attempt it alongside the rest. Fixes
+  [#76](https://github.com/hampsterx/async-kinesis/issues/76).
 - `consumer_checkpoint_success_total` / `_failure_total` now count actual backend
   persist operations. Previously, under `auto_checkpoint=False` (Redis / DynamoDB
   manual mode), the consumer-side wrapper incremented success on every

--- a/kinesis/checkpointers.py
+++ b/kinesis/checkpointers.py
@@ -272,10 +272,14 @@ class RedisCheckPointer(BaseHeartbeatCheckPointer):
     async def manual_checkpoint(self):
         # Pop per-shard on success so a mid-loop raise leaves the remaining
         # shards buffered for retry on the next manual_checkpoint() call.
+        # Only pop if the buffered value still matches what we just flushed:
+        # a concurrent checkpoint() during the await may have buffered a newer
+        # sequence for the same shard, which must not be dropped.
         for shard_id in list(self._manual_checkpoints):
             sequence = self._manual_checkpoints[shard_id]
             await self._checkpoint(shard_id, sequence)
-            self._manual_checkpoints.pop(shard_id, None)
+            if self._manual_checkpoints.get(shard_id) == sequence:
+                self._manual_checkpoints.pop(shard_id, None)
 
     async def _checkpoint(self, shard_id, sequence):
         try:

--- a/kinesis/checkpointers.py
+++ b/kinesis/checkpointers.py
@@ -270,12 +270,12 @@ class RedisCheckPointer(BaseHeartbeatCheckPointer):
         await self._checkpoint(shard_id, sequence)
 
     async def manual_checkpoint(self):
-        items = [(k, v) for k, v in self._manual_checkpoints.items()]
-
-        self._manual_checkpoints = {}
-
-        for shard_id, sequence in items:
+        # Pop per-shard on success so a mid-loop raise leaves the remaining
+        # shards buffered for retry on the next manual_checkpoint() call.
+        for shard_id in list(self._manual_checkpoints):
+            sequence = self._manual_checkpoints[shard_id]
             await self._checkpoint(shard_id, sequence)
+            self._manual_checkpoints.pop(shard_id, None)
 
     async def _checkpoint(self, shard_id, sequence):
         try:

--- a/kinesis/dynamodb.py
+++ b/kinesis/dynamodb.py
@@ -215,11 +215,15 @@ class DynamoDBCheckPointer(BaseHeartbeatCheckPointer):
 
         Pops per-shard on success so a mid-loop raise leaves the remaining
         shards buffered for retry on the next manual_checkpoint() call.
+        Only pop if the buffered value still matches what we just flushed:
+        a concurrent checkpoint() during the await may have buffered a newer
+        sequence for the same shard, which must not be dropped.
         """
         for shard_id in list(self._manual_checkpoints):
             sequence = self._manual_checkpoints[shard_id]
             await self._checkpoint(shard_id, sequence)
-            self._manual_checkpoints.pop(shard_id, None)
+            if self._manual_checkpoints.get(shard_id) == sequence:
+                self._manual_checkpoints.pop(shard_id, None)
 
     async def _checkpoint(self, shard_id: str, sequence: str) -> None:
         """Internal checkpoint implementation."""

--- a/kinesis/dynamodb.py
+++ b/kinesis/dynamodb.py
@@ -211,13 +211,15 @@ class DynamoDBCheckPointer(BaseHeartbeatCheckPointer):
         await self._checkpoint(shard_id, sequence)
 
     async def manual_checkpoint(self) -> None:
-        """Flush all manual checkpoints to DynamoDB."""
-        items = [(k, v) for k, v in self._manual_checkpoints.items()]
+        """Flush all manual checkpoints to DynamoDB.
 
-        self._manual_checkpoints = {}
-
-        for shard_id, sequence in items:
+        Pops per-shard on success so a mid-loop raise leaves the remaining
+        shards buffered for retry on the next manual_checkpoint() call.
+        """
+        for shard_id in list(self._manual_checkpoints):
+            sequence = self._manual_checkpoints[shard_id]
             await self._checkpoint(shard_id, sequence)
+            self._manual_checkpoints.pop(shard_id, None)
 
     async def _checkpoint(self, shard_id: str, sequence: str) -> None:
         """Internal checkpoint implementation."""

--- a/tests/test_dynamodb_checkpointer.py
+++ b/tests/test_dynamodb_checkpointer.py
@@ -312,6 +312,36 @@ class TestDynamoDBCheckPointer:
         assert collector.counters["consumer_checkpoint_success_total{shard_id=shard-002,stream_name=test-stream}"] == 1
 
     @pytest.mark.asyncio
+    async def test_manual_checkpoint_retains_buffer_on_mid_loop_failure(self, mock_dynamodb):
+        """A mid-loop exception leaves the unflushed shards in the buffer so
+        the caller can retry on the next manual_checkpoint() call."""
+        checkpointer = DynamoDBCheckPointer("test-app", auto_checkpoint=False)
+        await checkpointer._initialize()
+
+        await checkpointer.checkpoint("shard-001", "seq-123")
+        await checkpointer.checkpoint("shard-002", "seq-456")
+
+        # First update_item succeeds, second raises a transient backend error.
+        mock_dynamodb["table"].update_item.side_effect = [
+            {},
+            RuntimeError("backend flake"),
+        ]
+
+        with pytest.raises(RuntimeError, match="backend flake"):
+            await checkpointer.manual_checkpoint()
+
+        # shard-001 was popped on success, shard-002 raised before pop and stays
+        # buffered for retry. If the clear-before-iterate bug regressed, both
+        # would have been dropped and this would fail.
+        assert checkpointer._manual_checkpoints == {"shard-002": "seq-456"}
+
+        # A subsequent successful flush drains the remaining entry.
+        mock_dynamodb["table"].update_item.side_effect = None
+        mock_dynamodb["table"].update_item.return_value = {}
+        await checkpointer.manual_checkpoint()
+        assert checkpointer._manual_checkpoints == {}
+
+    @pytest.mark.asyncio
     async def test_checkpoint_failure_emits_metric(self, mock_dynamodb):
         """ConditionalCheckFailedException (lost ownership) counts as a failure."""
         from kinesis import InMemoryMetricsCollector

--- a/tests/test_metrics_unit.py
+++ b/tests/test_metrics_unit.py
@@ -552,8 +552,9 @@ class TestConsumerCheckpointMetrics:
         assert cp._manual_checkpoints == {"shard-0": "seq-1"}
 
     @pytest.mark.asyncio
-    async def test_manual_checkpoint_flush_emits_per_shard(self):
-        """manual_checkpoint() flush hits the real backend path, so emits one per shard."""
+    async def test_manual_checkpoint_flush_retains_buffer_on_failure(self):
+        """Mid-loop raise leaves remaining buffered shards for retry, and emits the
+        failure metric for the shard that actually tripped."""
         collector = InMemoryMetricsCollector()
         cp = await _make_redis_cp(auto_checkpoint=False)
         cp.bind_metrics(collector, {"stream_name": "test-stream"})
@@ -564,19 +565,74 @@ class TestConsumerCheckpointMetrics:
             await cp.checkpoint("shard-1", "seq-9")
             assert not any(key.startswith("consumer_checkpoint_") for key in collector.counters)
 
-            # Flush: client.getset returns None -> _checkpoint raises -> failure counter
-            # (We don't need happy-path Redis semantics here; we're verifying the emit
-            # wiring covers the real path, which is what matters.)
             with pytest.raises(NotImplementedError):
                 await cp.manual_checkpoint()
+
+            # shard-0 raised before being popped, shard-1 was never attempted.
+            # Both remain buffered so the caller can retry on the next flush.
+            assert cp._manual_checkpoints == {"shard-0": "seq-1", "shard-1": "seq-9"}
         finally:
             await cp.close()
 
-        # At least one shard's failure was emitted before the raise aborted the loop.
-        # This also documents the pre-existing lose-on-failure bug: the loop
-        # stops on first raise so the second shard's emit never happens.
+        # The failure that tripped the loop is observable via the metric.
         failure_key_0 = f"consumer_checkpoint_failure_total{{{_shard_labels('shard-0')}}}"
         assert collector.counters.get(failure_key_0) == 1
+        # Shards that never got attempted do not emit a failure counter.
+        failure_key_1 = f"consumer_checkpoint_failure_total{{{_shard_labels('shard-1')}}}"
+        assert failure_key_1 not in collector.counters
+
+    @pytest.mark.asyncio
+    async def test_manual_checkpoint_flush_partial_failure_retains_failed_shard(self):
+        """When the first shard succeeds and the second raises, only the failed
+        shard stays buffered; the successful shard is popped."""
+        collector = InMemoryMetricsCollector()
+        cp = await _make_redis_cp(auto_checkpoint=False)
+        cp.bind_metrics(collector, {"stream_name": "test-stream"})
+
+        # First call succeeds (returns previous val matching our ref), second raises.
+        previous_val = '{"ref": "' + cp.get_ref() + '", "ts": 0, "sequence": "seq-prev"}'
+        cp.client.getset = AsyncMock(side_effect=[previous_val, RuntimeError("flake")])
+
+        try:
+            await cp.checkpoint("shard-0", "seq-1")
+            await cp.checkpoint("shard-1", "seq-9")
+
+            with pytest.raises(RuntimeError):
+                await cp.manual_checkpoint()
+
+            # shard-0 was flushed and popped; shard-1 raised before pop, stays buffered.
+            assert cp._manual_checkpoints == {"shard-1": "seq-9"}
+        finally:
+            await cp.close()
+
+        assert collector.counters[f"consumer_checkpoint_success_total{{{_shard_labels('shard-0')}}}"] == 1
+        assert collector.counters[f"consumer_checkpoint_failure_total{{{_shard_labels('shard-1')}}}"] == 1
+
+    @pytest.mark.asyncio
+    async def test_manual_checkpoint_flush_retries_remaining_on_next_call(self):
+        """After a flush fails mid-loop, a subsequent manual_checkpoint() call
+        re-attempts the entries that were left in the buffer."""
+        collector = InMemoryMetricsCollector()
+        cp = await _make_redis_cp(auto_checkpoint=False)
+        cp.bind_metrics(collector, {"stream_name": "test-stream"})
+
+        previous_val = '{"ref": "' + cp.get_ref() + '", "ts": 0, "sequence": "seq-prev"}'
+        # First flush: shard-0 raises. Second flush: both shards succeed.
+        cp.client.getset = AsyncMock(side_effect=[RuntimeError("flake"), previous_val, previous_val])
+
+        try:
+            await cp.checkpoint("shard-0", "seq-1")
+            await cp.checkpoint("shard-1", "seq-9")
+
+            with pytest.raises(RuntimeError):
+                await cp.manual_checkpoint()
+            assert set(cp._manual_checkpoints) == {"shard-0", "shard-1"}
+
+            # Second flush drains the buffer.
+            await cp.manual_checkpoint()
+            assert cp._manual_checkpoints == {}
+        finally:
+            await cp.close()
 
     @pytest.mark.asyncio
     async def test_manual_checkpoint_flush_success_path_emits_per_shard(self):

--- a/tests/test_metrics_unit.py
+++ b/tests/test_metrics_unit.py
@@ -635,6 +635,36 @@ class TestConsumerCheckpointMetrics:
             await cp.close()
 
     @pytest.mark.asyncio
+    async def test_manual_checkpoint_flush_preserves_concurrent_newer_sequence(self):
+        """If checkpoint(shard, newer_seq) runs while manual_checkpoint is awaiting
+        the backend write for shard@older_seq, the newer buffered sequence must not
+        be popped (otherwise we'd silently lose it and process records twice)."""
+        cp = await _make_redis_cp(auto_checkpoint=False)
+
+        original_checkpoint = cp._checkpoint
+
+        async def interposing_checkpoint(shard_id, sequence):
+            # Simulate a concurrent checkpoint() landing during the in-flight flush:
+            # it overwrites the buffered entry with a newer sequence.
+            if shard_id == "shard-0" and sequence == "seq-1":
+                cp._manual_checkpoints["shard-0"] = "seq-2"
+            return await original_checkpoint(shard_id, sequence)
+
+        previous_val = '{"ref": "' + cp.get_ref() + '", "ts": 0, "sequence": "seq-prev"}'
+        cp.client.getset = AsyncMock(return_value=previous_val)
+        cp._checkpoint = interposing_checkpoint
+
+        try:
+            await cp.checkpoint("shard-0", "seq-1")
+            await cp.manual_checkpoint()
+
+            # seq-2 was buffered during the await; the conditional pop must have
+            # spared it. A subsequent flush will drain it on the next call.
+            assert cp._manual_checkpoints == {"shard-0": "seq-2"}
+        finally:
+            await cp.close()
+
+    @pytest.mark.asyncio
     async def test_manual_checkpoint_flush_success_path_emits_per_shard(self):
         """Happy-path manual flush on MemoryCheckPointer-style emission (direct exercise)."""
         collector = InMemoryMetricsCollector()


### PR DESCRIPTION
## Summary

Fixes #76. `RedisCheckPointer.manual_checkpoint()` and `DynamoDBCheckPointer.manual_checkpoint()` both cleared `_manual_checkpoints` before iterating. If the backend raised for shard N, the loop aborted and the entries for shards N+1..end were already evicted from the buffer, with no way for the caller to retry them.

After this change, shards are popped from the buffer individually after a successful backend write. A mid-loop raise leaves every unflushed entry (including the one that tripped) in the buffer for retry on the next `manual_checkpoint()` call.

## Changes

- `kinesis/checkpointers.py`: `RedisCheckPointer.manual_checkpoint()` iterates a snapshot of keys, reads the sequence fresh, awaits `_checkpoint()`, then pops on success.
- `kinesis/dynamodb.py`: same pattern for `DynamoDBCheckPointer.manual_checkpoint()`.
- Tests:
  - `test_manual_checkpoint_flush_retains_buffer_on_failure` (Redis, full-fail): both shards stay buffered, only the shard that was actually attempted emits a failure metric.
  - `test_manual_checkpoint_flush_partial_failure_retains_failed_shard` (Redis): first shard succeeds and is popped, second raises and stays buffered.
  - `test_manual_checkpoint_flush_retries_remaining_on_next_call` (Redis): two-flush scenario, second flush drains the buffer.
  - `test_manual_checkpoint_retains_buffer_on_mid_loop_failure` (DynamoDB): parallel coverage on the DynamoDB backend.
  - Renamed the pre-existing `test_manual_checkpoint_flush_emits_per_shard`, which previously documented the lose-on-failure bug, and updated its assertions.

## Backwards compatibility

- Behavior change on the **failure path only**. A caller that was previously catching the raise from `manual_checkpoint()` and treating the buffer as drained will now see residual entries the next time they call `checkpoint()` or `manual_checkpoint()`. On success, behavior is unchanged (all shards are flushed and the buffer is empty).
- No API changes, no metric label changes.

## Residual risks (out of scope for this PR)

Both external reviewers flagged pre-existing issues that are not introduced or made worse here:

- **Poison pill**: a shard that fails permanently (e.g. lost ownership) now stays at the head of the buffer and every subsequent flush aborts on it, blocking later shards. This tradeoff is explicitly called out in #76 ("the caller needs to decide when to give up"). A follow-up could introduce continue-on-error or per-shard eviction.
- **Concurrent mutation**: `_manual_checkpoints` was never concurrent-safe. The snapshot + `pop(..., None)` pattern is no worse than the prior clear-before-iterate, but a concurrent `checkpoint()` during an in-flight flush can still overwrite or lose a newer sequence for the same shard.
- **Code duplication**: the two `manual_checkpoint()` implementations are now identical. Consolidating to `BaseHeartbeatCheckPointer` is a separate refactor.

## Test plan

- [x] 4 new unit tests + 1 updated test, all green.
- [x] Full non-Docker suite: 169 passed, 7 skipped.
- [x] `black --check` + `flake8` clean on the changed files.
- [ ] Not exercised: real Redis / real DynamoDB integration (fix is in the flush loop control flow, not the backend write itself).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed checkpoint buffering to preserve unflushed entries when exceptions occur during checkpoint operations. Previously, failed checkpoints would be lost; they are now retained and will be retried on subsequent checkpoint attempts, improving reliability.

* **Tests**
  * Added test coverage for checkpoint failure and retry scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->