### PR TITLE
fix(dynamodb): propagate endpoint_url to all resource/client calls

### DIFF
--- a/kinesis/dynamodb.py
+++ b/kinesis/dynamodb.py
@@ -138,7 +138,11 @@ class DynamoDBCheckPointer(BaseHeartbeatCheckPointer):
 
         # Enable TTL on the ttl field
         try:
-            async with self._session.client("dynamodb", region_name=self.region_name) as client:
+            async with self._session.client(
+                "dynamodb",
+                endpoint_url=self.endpoint_url,
+                region_name=self.region_name,
+            ) as client:
                 await client.update_time_to_live(
                     TableName=self.table_name,
                     TimeToLiveSpecification={
@@ -172,7 +176,11 @@ class DynamoDBCheckPointer(BaseHeartbeatCheckPointer):
 
         value["ttl"] = self.get_ttl()
 
-        async with self._session.resource("dynamodb", region_name=self.region_name) as dynamodb:
+        async with self._session.resource(
+            "dynamodb",
+            endpoint_url=self.endpoint_url,
+            region_name=self.region_name,
+        ) as dynamodb:
             table = await dynamodb.Table(self.table_name)
 
             try:
@@ -226,7 +234,11 @@ class DynamoDBCheckPointer(BaseHeartbeatCheckPointer):
 
         key = self.get_key(shard_id)
 
-        async with self._session.resource("dynamodb", region_name=self.region_name) as dynamodb:
+        async with self._session.resource(
+            "dynamodb",
+            endpoint_url=self.endpoint_url,
+            region_name=self.region_name,
+        ) as dynamodb:
             table = await dynamodb.Table(self.table_name)
 
             # Emission is scoped to the update_item call only. Init errors and
@@ -276,7 +288,11 @@ class DynamoDBCheckPointer(BaseHeartbeatCheckPointer):
         key = self.get_key(shard_id)
         sequence = self._items.get(shard_id)
 
-        async with self._session.resource("dynamodb", region_name=self.region_name) as dynamodb:
+        async with self._session.resource(
+            "dynamodb",
+            endpoint_url=self.endpoint_url,
+            region_name=self.region_name,
+        ) as dynamodb:
             table = await dynamodb.Table(self.table_name)
 
             # Clear ownership but keep sequence number
@@ -310,7 +326,11 @@ class DynamoDBCheckPointer(BaseHeartbeatCheckPointer):
         for retry in range(max_retries):
             ts = self.get_ts()
 
-            async with self._session.resource("dynamodb", region_name=self.region_name) as dynamodb:
+            async with self._session.resource(
+                "dynamodb",
+                endpoint_url=self.endpoint_url,
+                region_name=self.region_name,
+            ) as dynamodb:
                 table = await dynamodb.Table(self.table_name)
 
                 # First, try to create a new record

--- a/tests/test_dynamodb_checkpointer.py
+++ b/tests/test_dynamodb_checkpointer.py
@@ -434,17 +434,17 @@ class TestDynamoDBCheckPointer:
         """session.resource(...) most recent call must include endpoint_url kwarg."""
         assert mock_session.resource.called, "session.resource was not called"
         _args, kwargs = mock_session.resource.call_args
-        assert kwargs.get("endpoint_url") == self.ENDPOINT_URL, (
-            f"expected endpoint_url={self.ENDPOINT_URL!r}, got kwargs={kwargs!r}"
-        )
+        assert (
+            kwargs.get("endpoint_url") == self.ENDPOINT_URL
+        ), f"expected endpoint_url={self.ENDPOINT_URL!r}, got kwargs={kwargs!r}"
 
     def _assert_endpoint_url_in_last_client_call(self, mock_session):
         """session.client(...) most recent call must include endpoint_url kwarg."""
         assert mock_session.client.called, "session.client was not called"
         _args, kwargs = mock_session.client.call_args
-        assert kwargs.get("endpoint_url") == self.ENDPOINT_URL, (
-            f"expected endpoint_url={self.ENDPOINT_URL!r}, got kwargs={kwargs!r}"
-        )
+        assert (
+            kwargs.get("endpoint_url") == self.ENDPOINT_URL
+        ), f"expected endpoint_url={self.ENDPOINT_URL!r}, got kwargs={kwargs!r}"
 
     @pytest.mark.asyncio
     async def test_endpoint_url_propagates_to_do_heartbeat(self, mock_dynamodb):
@@ -498,9 +498,7 @@ class TestDynamoDBCheckPointer:
             {"Error": {"Code": "ResourceNotFoundException"}}, "DescribeTable"
         )
 
-        checkpointer = DynamoDBCheckPointer(
-            "test-app", endpoint_url=self.ENDPOINT_URL, create_table=True
-        )
+        checkpointer = DynamoDBCheckPointer("test-app", endpoint_url=self.ENDPOINT_URL, create_table=True)
         await checkpointer._initialize()
 
         self._assert_endpoint_url_in_last_client_call(mock_dynamodb["session"])

--- a/tests/test_dynamodb_checkpointer.py
+++ b/tests/test_dynamodb_checkpointer.py
@@ -417,3 +417,90 @@ class TestDynamoDBCheckPointer:
         assert sequence is None
         # Verify get_item was called 3 times (max retries)
         assert mock_dynamodb["table"].get_item.call_count == 3
+
+    # ------------------------------------------------------------------
+    # endpoint_url propagation regression tests
+    #
+    # Historically, endpoint_url was only honoured during _initialize() (table
+    # discovery). Every subsequent per-operation session.resource / session.client
+    # call bypassed it and silently hit real AWS, breaking LocalStack / DynamoDB
+    # Local based dev and testing for any flow beyond startup. These tests assert
+    # that endpoint_url is threaded through each of the 5 remaining call sites.
+    # ------------------------------------------------------------------
+
+    ENDPOINT_URL = "http://localhost:4566"
+
+    def _assert_endpoint_url_in_last_resource_call(self, mock_session):
+        """session.resource(...) most recent call must include endpoint_url kwarg."""
+        assert mock_session.resource.called, "session.resource was not called"
+        _args, kwargs = mock_session.resource.call_args
+        assert kwargs.get("endpoint_url") == self.ENDPOINT_URL, (
+            f"expected endpoint_url={self.ENDPOINT_URL!r}, got kwargs={kwargs!r}"
+        )
+
+    def _assert_endpoint_url_in_last_client_call(self, mock_session):
+        """session.client(...) most recent call must include endpoint_url kwarg."""
+        assert mock_session.client.called, "session.client was not called"
+        _args, kwargs = mock_session.client.call_args
+        assert kwargs.get("endpoint_url") == self.ENDPOINT_URL, (
+            f"expected endpoint_url={self.ENDPOINT_URL!r}, got kwargs={kwargs!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_endpoint_url_propagates_to_do_heartbeat(self, mock_dynamodb):
+        checkpointer = DynamoDBCheckPointer("test-app", endpoint_url=self.ENDPOINT_URL)
+        await checkpointer._initialize()
+        mock_dynamodb["session"].resource.reset_mock()
+
+        await checkpointer.do_heartbeat("shard-001", {"ref": "x", "ts": 1, "sequence": "s"})
+
+        self._assert_endpoint_url_in_last_resource_call(mock_dynamodb["session"])
+
+    @pytest.mark.asyncio
+    async def test_endpoint_url_propagates_to_checkpoint(self, mock_dynamodb):
+        checkpointer = DynamoDBCheckPointer("test-app", endpoint_url=self.ENDPOINT_URL)
+        await checkpointer._initialize()
+        mock_dynamodb["session"].resource.reset_mock()
+
+        mock_dynamodb["table"].update_item.return_value = {}
+        await checkpointer._checkpoint("shard-001", "seq-123")
+
+        self._assert_endpoint_url_in_last_resource_call(mock_dynamodb["session"])
+
+    @pytest.mark.asyncio
+    async def test_endpoint_url_propagates_to_deallocate(self, mock_dynamodb):
+        checkpointer = DynamoDBCheckPointer("test-app", endpoint_url=self.ENDPOINT_URL)
+        await checkpointer._initialize()
+        checkpointer._items["shard-001"] = "seq-123"
+        mock_dynamodb["session"].resource.reset_mock()
+
+        mock_dynamodb["table"].update_item.return_value = {}
+        await checkpointer.deallocate("shard-001")
+
+        self._assert_endpoint_url_in_last_resource_call(mock_dynamodb["session"])
+
+    @pytest.mark.asyncio
+    async def test_endpoint_url_propagates_to_allocate(self, mock_dynamodb):
+        checkpointer = DynamoDBCheckPointer("test-app", endpoint_url=self.ENDPOINT_URL)
+        await checkpointer._initialize()
+        mock_dynamodb["session"].resource.reset_mock()
+
+        mock_dynamodb["table"].put_item.return_value = {}
+        await checkpointer.allocate("shard-001")
+
+        self._assert_endpoint_url_in_last_resource_call(mock_dynamodb["session"])
+
+    @pytest.mark.asyncio
+    async def test_endpoint_url_propagates_to_create_table_ttl(self, mock_dynamodb):
+        """_create_table's TTL update uses session.client; a missed kwarg would be
+        hidden by the ClientError-is-logged-as-warning fallback, so assert explicitly."""
+        mock_dynamodb["table"].load.side_effect = ClientError(
+            {"Error": {"Code": "ResourceNotFoundException"}}, "DescribeTable"
+        )
+
+        checkpointer = DynamoDBCheckPointer(
+            "test-app", endpoint_url=self.ENDPOINT_URL, create_table=True
+        )
+        await checkpointer._initialize()
+
+        self._assert_endpoint_url_in_last_client_call(mock_dynamodb["session"])


### PR DESCRIPTION
## Summary

`DynamoDBCheckPointer` now respects the configured `endpoint_url` for **all** operations, not just initial table discovery. Previously it was only applied during `_initialize()`, so any checkpointer running against LocalStack / DynamoDB Local would silently hit real AWS for heartbeats, checkpoints, `allocate`, `deallocate`, and the `_create_table` TTL enable step.

Fixes the bug surfaced during review of #75.

### What changed

Thread `endpoint_url=self.endpoint_url` through the 5 remaining `session.resource(...)` / `session.client(...)` call sites in ``kinesis/dynamodb.py``:

- ``_create_table`` TTL update (`session.client`)
- ``do_heartbeat`` (`session.resource`)
- ``_checkpoint`` (`session.resource`)
- ``deallocate`` (`session.resource`)
- ``allocate`` retry loop (`session.resource`)

One regression test per call site asserts the kwarg is threaded through. The TTL update in particular only logs a `ClientError` as a warning, so a missed kwarg there would not surface via normal flow, hence the explicit spy assertion.

## Backwards compatibility

No break.

- Production callers with `endpoint_url=None` (default): unchanged behaviour. `endpoint_url=None` is a standard boto3 no-op.
- Callers with `endpoint_url` set (LocalStack, DynamoDB Local, dev emulators): the value is now honoured for every operation. Previously it was silently ignored for everything except startup.

There's no conceivable case where a caller relied on the old half-broken behaviour.

## Test plan

- [x] 5 new regression tests, one per call site, asserting `endpoint_url` is passed to `session.resource` / `session.client`
- [x] Existing 18 DynamoDB checkpointer tests still pass (mock-based, endpoint_url irrelevant)
- [x] Full non-integration suite green: 171 passed, 7 skipped
- [x] External review (Codex + Gemini, focused depth): no blocking findings

## Related

- PR #75 (merged), review surfaced this pre-existing bug

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where custom endpoint URL configuration was not being applied to all DynamoDB operations.

* **Tests**
  * Added regression tests to verify endpoint URL propagation is consistently maintained across all DynamoDB operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->