### PR TITLE
Fix #81: Checkpointer: three pre-existing correctness papercuts in BaseHeartbeatCheckPointer

### DIFF
--- a/kinesis/checkpointers.py
+++ b/kinesis/checkpointers.py
@@ -5,6 +5,7 @@ import os
 from datetime import datetime, timezone
 from typing import Any, Dict, Optional, Protocol, Tuple, Union
 
+from .exceptions import CheckpointStateConflict
 from .metrics import MetricsCollector, MetricType, get_metrics_collector
 
 log = logging.getLogger(__name__)
@@ -169,6 +170,10 @@ class BaseHeartbeatCheckPointer(BaseCheckPointer):
     async def close(self):
         log.debug("Cancelling heartbeat task..")
         self.heartbeat_task.cancel()
+        try:
+            await self.heartbeat_task
+        except asyncio.CancelledError:
+            pass
 
         await super().close()
 
@@ -177,7 +182,7 @@ class BaseHeartbeatCheckPointer(BaseCheckPointer):
             await asyncio.sleep(self.heartbeat_frequency)
 
             # todo: don't heartbeat if checkpoint already updated it recently
-            for shard_id, sequence in self._items.items():
+            for shard_id, sequence in list(self._items.items()):
                 key = self.get_key(shard_id)
                 val = {"ref": self.get_ref(), "ts": self.get_ts(), "sequence": sequence}
                 log.debug("Heartbeating {}@{}".format(shard_id, sequence))
@@ -291,13 +296,13 @@ class RedisCheckPointer(BaseHeartbeatCheckPointer):
             previous_val = json.loads(previous_val) if previous_val else None
 
             if not previous_val:
-                raise NotImplementedError(
+                raise CheckpointStateConflict(
                     "{} checkpointed on {} but key did not exist?".format(self.get_ref(), shard_id)
                 )
 
             if previous_val["ref"] != self.get_ref():
-                raise NotImplementedError(
-                    "{} checkpointed on {} but ref is different {}".format(self.get_ref(), shard_id, val["ref"])
+                raise CheckpointStateConflict(
+                    "{} checkpointed on {} but ref is different {}".format(self.get_ref(), shard_id, previous_val["ref"])
                 )
 
             log.debug("{} checkpointed on {}@{}".format(self.get_ref(), shard_id, sequence))

--- a/kinesis/exceptions.py
+++ b/kinesis/exceptions.py
@@ -24,3 +24,7 @@ class UnknownException(Exception):
 
 class ValidationError(Exception):
     pass
+
+
+class CheckpointStateConflict(Exception):
+    pass


### PR DESCRIPTION
## Summary

Fix three correctness issues in BaseHeartbeatCheckPointer: await cancelled heartbeat task in close(), snapshot dict before iterating in heartbeat(), and replace NotImplementedError with a proper domain exception using correct variable reference.

## Approach

C1: In `close()`, after calling `self.heartbeat_task.cancel()`, add a try/await/except block to await the task and suppress `CancelledError`, matching the pattern already used in the test helper. C2: In `heartbeat()`, change `self._items.items()` to `list(self._items.items())` to snapshot the dictionary before iterating, preventing RuntimeError from concurrent mutation during the async yield. C3: First, add a dedicated exception class (e.g., `CheckpointStateConflict`) to `kinesis/exceptions.py`. Then in `checkpointers.py`, import it and replace both `NotImplementedError` raises with `CheckpointStateConflict`. Also fix the second raise's format string to use `previous_val["ref"]` instead of `val["ref"]` since the intent is to log the mismatched ref from the stored checkpoint.

## Files Changed

- `kinesis/exceptions.py`
- `kinesis/checkpointers.py`

## Related Issue

Fixes #81

## Testing

Verified the change manually. Let me know if you'd like any additional tests or adjustments.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential runtime issue when internal state is modified during heartbeat operations.

* **Refactor**
  * Improved error reporting for checkpoint state conflicts with more specific error conditions.
  * Enhanced graceful shutdown handling to properly clean up background tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->