### PR TITLE
fix(checkpointer): best-effort manual_checkpoint() with compound raise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ### Fixed
 - `RedisCheckPointer.manual_checkpoint()` and `DynamoDBCheckPointer.manual_checkpoint()`
+  are now best-effort: every buffered shard is attempted on each call, and
+  per-shard failures are collected rather than aborting on the first raise.
+  Previously, a shard that repeatedly failed at the head of the buffer (lost
+  lease, persistent backend error, malformed sequence) would block every shard
+  behind it from ever being flushed, because dict iteration is insertion-ordered.
+  Failing shards still stay buffered for retry; successful shards are popped.
+  When one or more shards fail, the call raises a new `CheckpointFlushError`
+  carrying the per-shard failures in `.errors`. Fixes
+  [#79](https://github.com/hampsterx/async-kinesis/issues/79).
+- `RedisCheckPointer.manual_checkpoint()` and `DynamoDBCheckPointer.manual_checkpoint()`
   no longer drop buffered checkpoints on a mid-loop exception. Previously, both
   cleared `_manual_checkpoints` before iterating, so if the backend raised for
   shard N, the entries for shards N+1..end were evicted and never retried.
@@ -12,6 +22,13 @@
   that tripped also stays buffered (it was not successfully persisted), so
   callers that retry will re-attempt it alongside the rest. Fixes
   [#76](https://github.com/hampsterx/async-kinesis/issues/76).
+
+### Added
+- `CheckpointFlushError` exception, exported from the top-level `kinesis`
+  package. Raised by `manual_checkpoint()` when one or more per-shard flushes
+  fail. Carries `.errors: list[tuple[str, BaseException]]` in attempt order;
+  `__cause__` is set to the first underlying exception so tracebacks still
+  show a real failure.
 - `consumer_checkpoint_success_total` / `_failure_total` now count actual backend
   persist operations. Previously, under `auto_checkpoint=False` (Redis / DynamoDB
   manual mode), the consumer-side wrapper incremented success on every
@@ -22,6 +39,13 @@
   Consumer appear under a new sentinel `stream_name="<standalone>"`.
 
 ### Backwards compatibility
+- **`manual_checkpoint()` exception type**: callers that caught the inner
+  exception type directly (e.g. `except RuntimeError:`, `except ClientError:`)
+  will no longer match, because the call now wraps per-shard failures in
+  `CheckpointFlushError`. Catch `CheckpointFlushError` and inspect `.errors`
+  for per-shard detail, or broaden to `except Exception:` if the distinction
+  does not matter. `CheckpointFlushError` subclasses `Exception`, so existing
+  `except Exception:` clauses continue to work.
 - **Shared checkpointer across Consumers** (`BaseCheckPointer` subclasses only):
   reusing a single `MemoryCheckPointer` / `RedisCheckPointer` / `DynamoDBCheckPointer`
   instance across multiple `Consumer`s with different `stream_name` or different

--- a/kinesis/__init__.py
+++ b/kinesis/__init__.py
@@ -1,5 +1,5 @@
 from .aggregators import ListAggregator, NetstringAggregator, NewlineAggregator, SimpleAggregator
-from .checkpointers import MemoryCheckPointer, RedisCheckPointer
+from .checkpointers import CheckpointFlushError, MemoryCheckPointer, RedisCheckPointer
 from .consumer import Consumer
 from .metrics import (
     InMemoryMetricsCollector,

--- a/kinesis/checkpointers.py
+++ b/kinesis/checkpointers.py
@@ -3,13 +3,32 @@ import json
 import logging
 import os
 from datetime import datetime, timezone
-from typing import Any, Dict, Optional, Protocol, Tuple, Union
+from typing import Any, Dict, List, Optional, Protocol, Tuple, Union
 
 from .metrics import MetricsCollector, MetricType, get_metrics_collector
 
 log = logging.getLogger(__name__)
 
 STANDALONE_STREAM_LABEL = "<standalone>"
+
+
+class CheckpointFlushError(Exception):
+    """Raised by ``manual_checkpoint()`` when one or more per-shard flushes fail.
+
+    ``manual_checkpoint()`` is best-effort: it attempts every buffered shard and
+    collects per-shard failures into ``.errors`` rather than aborting on the
+    first raise. Shards that raised remain in the buffer for the next flush;
+    shards that succeeded are popped.
+
+    ``.errors`` is a list of ``(shard_id, exception)`` tuples in the order the
+    shards were attempted. The original ``__cause__`` is set to the first
+    underlying exception so the traceback shows at least one real failure.
+    """
+
+    def __init__(self, errors: List[Tuple[str, BaseException]]):
+        self.errors = errors
+        shard_ids = ", ".join(shard_id for shard_id, _ in errors)
+        super().__init__(f"{len(errors)} shard(s) failed to checkpoint: {shard_ids}")
 
 
 class CheckPointer(Protocol):
@@ -270,16 +289,35 @@ class RedisCheckPointer(BaseHeartbeatCheckPointer):
         await self._checkpoint(shard_id, sequence)
 
     async def manual_checkpoint(self):
-        # Pop per-shard on success so a mid-loop raise leaves the remaining
-        # shards buffered for retry on the next manual_checkpoint() call.
-        # Only pop if the buffered value still matches what we just flushed:
-        # a concurrent checkpoint() during the await may have buffered a newer
-        # sequence for the same shard, which must not be dropped.
+        """Flush all buffered manual checkpoints, best-effort.
+
+        Every buffered shard is attempted on each call. A shard whose flush
+        raises is left in the buffer (so a poison-pill shard does not block
+        the shards behind it from ever being flushed); shards that succeed
+        are popped. The success-path pop is guarded by a value-match check,
+        so a concurrent ``checkpoint()`` that buffered a newer sequence for
+        the same shard mid-flight is not silently dropped.
+
+        Raises:
+            CheckpointFlushError: if one or more shards raised. The compound
+                exception carries the per-shard failures in ``.errors``.
+                Per-shard ``consumer_checkpoint_failure_total`` counters are
+                emitted from inside ``_checkpoint`` as each flush fails, so
+                callers should monitor that metric for alerting rather than
+                parsing the exception.
+        """
+        errors: List[Tuple[str, BaseException]] = []
         for shard_id in list(self._manual_checkpoints):
             sequence = self._manual_checkpoints[shard_id]
-            await self._checkpoint(shard_id, sequence)
+            try:
+                await self._checkpoint(shard_id, sequence)
+            except Exception as exc:
+                errors.append((shard_id, exc))
+                continue
             if self._manual_checkpoints.get(shard_id) == sequence:
                 self._manual_checkpoints.pop(shard_id, None)
+        if errors:
+            raise CheckpointFlushError(errors) from errors[0][1]
 
     async def _checkpoint(self, shard_id, sequence):
         try:

--- a/kinesis/dynamodb.py
+++ b/kinesis/dynamodb.py
@@ -8,9 +8,9 @@ import asyncio
 import logging
 import os
 from datetime import datetime, timezone
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
-from .checkpointers import BaseHeartbeatCheckPointer
+from .checkpointers import BaseHeartbeatCheckPointer, CheckpointFlushError
 
 log = logging.getLogger(__name__)
 
@@ -219,19 +219,35 @@ class DynamoDBCheckPointer(BaseHeartbeatCheckPointer):
         await self._checkpoint(shard_id, sequence)
 
     async def manual_checkpoint(self) -> None:
-        """Flush all manual checkpoints to DynamoDB.
+        """Flush all buffered manual checkpoints to DynamoDB, best-effort.
 
-        Pops per-shard on success so a mid-loop raise leaves the remaining
-        shards buffered for retry on the next manual_checkpoint() call.
-        Only pop if the buffered value still matches what we just flushed:
-        a concurrent checkpoint() during the await may have buffered a newer
-        sequence for the same shard, which must not be dropped.
+        Every buffered shard is attempted on each call. A shard whose flush
+        raises is left in the buffer (so a poison-pill shard does not block
+        the shards behind it from ever being flushed); shards that succeed
+        are popped. The success-path pop is guarded by a value-match check,
+        so a concurrent ``checkpoint()`` that buffered a newer sequence for
+        the same shard mid-flight is not silently dropped.
+
+        Raises:
+            CheckpointFlushError: if one or more shards raised. The compound
+                exception carries the per-shard failures in ``.errors``.
+                Per-shard ``consumer_checkpoint_failure_total`` counters are
+                emitted from inside ``_checkpoint`` as each flush fails, so
+                callers should monitor that metric for alerting rather than
+                parsing the exception.
         """
+        errors: List[Tuple[str, BaseException]] = []
         for shard_id in list(self._manual_checkpoints):
             sequence = self._manual_checkpoints[shard_id]
-            await self._checkpoint(shard_id, sequence)
+            try:
+                await self._checkpoint(shard_id, sequence)
+            except Exception as exc:
+                errors.append((shard_id, exc))
+                continue
             if self._manual_checkpoints.get(shard_id) == sequence:
                 self._manual_checkpoints.pop(shard_id, None)
+        if errors:
+            raise CheckpointFlushError(errors) from errors[0][1]
 
     async def _checkpoint(self, shard_id: str, sequence: str) -> None:
         """Internal checkpoint implementation."""

--- a/tests/test_dynamodb_checkpointer.py
+++ b/tests/test_dynamodb_checkpointer.py
@@ -313,8 +313,10 @@ class TestDynamoDBCheckPointer:
 
     @pytest.mark.asyncio
     async def test_manual_checkpoint_retains_buffer_on_mid_loop_failure(self, mock_dynamodb):
-        """A mid-loop exception leaves the unflushed shards in the buffer so
-        the caller can retry on the next manual_checkpoint() call."""
+        """A per-shard flush raise leaves only the failing shard in the buffer
+        so the caller can retry on the next manual_checkpoint() call."""
+        from kinesis import CheckpointFlushError
+
         checkpointer = DynamoDBCheckPointer("test-app", auto_checkpoint=False)
         await checkpointer._initialize()
 
@@ -327,8 +329,11 @@ class TestDynamoDBCheckPointer:
             RuntimeError("backend flake"),
         ]
 
-        with pytest.raises(RuntimeError, match="backend flake"):
+        with pytest.raises(CheckpointFlushError) as exc_info:
             await checkpointer.manual_checkpoint()
+
+        assert [shard_id for shard_id, _ in exc_info.value.errors] == ["shard-002"]
+        assert isinstance(exc_info.value.errors[0][1], RuntimeError)
 
         # shard-001 was popped on success, shard-002 raised before pop and stays
         # buffered for retry. If the clear-before-iterate bug regressed, both
@@ -340,6 +345,57 @@ class TestDynamoDBCheckPointer:
         mock_dynamodb["table"].update_item.return_value = {}
         await checkpointer.manual_checkpoint()
         assert checkpointer._manual_checkpoints == {}
+
+    @pytest.mark.asyncio
+    async def test_manual_checkpoint_continues_past_head_failure(self, mock_dynamodb):
+        """Issue #79: a shard that fails at the head of the buffer must not
+        block healthy shards behind it from being flushed. Poison-pill fix."""
+        from kinesis import CheckpointFlushError
+
+        checkpointer = DynamoDBCheckPointer("test-app", auto_checkpoint=False)
+        await checkpointer._initialize()
+
+        await checkpointer.checkpoint("shard-001", "seq-123")
+        await checkpointer.checkpoint("shard-002", "seq-456")
+
+        # shard-001 raises (poison), shard-002 succeeds. Without the fix the
+        # loop would abort on shard-001 and never attempt shard-002.
+        mock_dynamodb["table"].update_item.side_effect = [
+            RuntimeError("poison"),
+            {},
+        ]
+
+        with pytest.raises(CheckpointFlushError) as exc_info:
+            await checkpointer.manual_checkpoint()
+
+        assert [shard_id for shard_id, _ in exc_info.value.errors] == ["shard-001"]
+
+        # shard-001 still buffered, shard-002 was attempted and popped.
+        assert checkpointer._manual_checkpoints == {"shard-001": "seq-123"}
+
+    @pytest.mark.asyncio
+    async def test_manual_checkpoint_collects_all_failures(self, mock_dynamodb):
+        """When every shard fails, CheckpointFlushError.errors lists every
+        failure in insertion order; the buffer is unchanged."""
+        from kinesis import CheckpointFlushError
+
+        checkpointer = DynamoDBCheckPointer("test-app", auto_checkpoint=False)
+        await checkpointer._initialize()
+
+        await checkpointer.checkpoint("shard-001", "seq-123")
+        await checkpointer.checkpoint("shard-002", "seq-456")
+
+        mock_dynamodb["table"].update_item.side_effect = [
+            RuntimeError("first"),
+            RuntimeError("second"),
+        ]
+
+        with pytest.raises(CheckpointFlushError) as exc_info:
+            await checkpointer.manual_checkpoint()
+
+        assert [shard_id for shard_id, _ in exc_info.value.errors] == ["shard-001", "shard-002"]
+        assert [str(exc) for _, exc in exc_info.value.errors] == ["first", "second"]
+        assert checkpointer._manual_checkpoints == {"shard-001": "seq-123", "shard-002": "seq-456"}
 
     @pytest.mark.asyncio
     async def test_checkpoint_failure_emits_metric(self, mock_dynamodb):

--- a/tests/test_metrics_unit.py
+++ b/tests/test_metrics_unit.py
@@ -9,6 +9,7 @@ from aiohttp import ClientConnectionError
 from botocore.exceptions import ClientError
 
 from kinesis import (
+    CheckpointFlushError,
     InMemoryMetricsCollector,
     MemoryCheckPointer,
     MetricType,
@@ -553,8 +554,8 @@ class TestConsumerCheckpointMetrics:
 
     @pytest.mark.asyncio
     async def test_manual_checkpoint_flush_retains_buffer_on_failure(self):
-        """Mid-loop raise leaves remaining buffered shards for retry, and emits the
-        failure metric for the shard that actually tripped."""
+        """When every attempted shard raises, all stay buffered for retry and each
+        emits its own failure metric."""
         collector = InMemoryMetricsCollector()
         cp = await _make_redis_cp(auto_checkpoint=False)
         cp.bind_metrics(collector, {"stream_name": "test-stream"})
@@ -565,21 +566,21 @@ class TestConsumerCheckpointMetrics:
             await cp.checkpoint("shard-1", "seq-9")
             assert not any(key.startswith("consumer_checkpoint_") for key in collector.counters)
 
-            with pytest.raises(NotImplementedError):
+            with pytest.raises(CheckpointFlushError) as exc_info:
                 await cp.manual_checkpoint()
 
-            # shard-0 raised before being popped, shard-1 was never attempted.
-            # Both remain buffered so the caller can retry on the next flush.
+            # Best-effort flush: every shard was attempted, every shard raised.
+            assert [shard_id for shard_id, _ in exc_info.value.errors] == ["shard-0", "shard-1"]
+            assert all(isinstance(exc, NotImplementedError) for _, exc in exc_info.value.errors)
+
+            # Both failed, so both remain buffered.
             assert cp._manual_checkpoints == {"shard-0": "seq-1", "shard-1": "seq-9"}
         finally:
             await cp.close()
 
-        # The failure that tripped the loop is observable via the metric.
-        failure_key_0 = f"consumer_checkpoint_failure_total{{{_shard_labels('shard-0')}}}"
-        assert collector.counters.get(failure_key_0) == 1
-        # Shards that never got attempted do not emit a failure counter.
-        failure_key_1 = f"consumer_checkpoint_failure_total{{{_shard_labels('shard-1')}}}"
-        assert failure_key_1 not in collector.counters
+        # Both shards emitted their own failure counter from inside _checkpoint.
+        assert collector.counters[f"consumer_checkpoint_failure_total{{{_shard_labels('shard-0')}}}"] == 1
+        assert collector.counters[f"consumer_checkpoint_failure_total{{{_shard_labels('shard-1')}}}"] == 1
 
     @pytest.mark.asyncio
     async def test_manual_checkpoint_flush_partial_failure_retains_failed_shard(self):
@@ -597,8 +598,11 @@ class TestConsumerCheckpointMetrics:
             await cp.checkpoint("shard-0", "seq-1")
             await cp.checkpoint("shard-1", "seq-9")
 
-            with pytest.raises(RuntimeError):
+            with pytest.raises(CheckpointFlushError) as exc_info:
                 await cp.manual_checkpoint()
+
+            assert [shard_id for shard_id, _ in exc_info.value.errors] == ["shard-1"]
+            assert isinstance(exc_info.value.errors[0][1], RuntimeError)
 
             # shard-0 was flushed and popped; shard-1 raised before pop, stays buffered.
             assert cp._manual_checkpoints == {"shard-1": "seq-9"}
@@ -609,24 +613,99 @@ class TestConsumerCheckpointMetrics:
         assert collector.counters[f"consumer_checkpoint_failure_total{{{_shard_labels('shard-1')}}}"] == 1
 
     @pytest.mark.asyncio
+    async def test_manual_checkpoint_continues_past_head_failure(self):
+        """Issue #79: a shard that repeatedly fails at the head of the buffer must
+        not block healthy shards behind it from being flushed. Poison-pill fix."""
+        collector = InMemoryMetricsCollector()
+        cp = await _make_redis_cp(auto_checkpoint=False)
+        cp.bind_metrics(collector, {"stream_name": "test-stream"})
+
+        # shard-0 always raises; shard-1 always succeeds.
+        previous_val = '{"ref": "' + cp.get_ref() + '", "ts": 0, "sequence": "seq-prev"}'
+        cp.client.getset = AsyncMock(side_effect=[RuntimeError("poison"), previous_val])
+
+        try:
+            await cp.checkpoint("shard-0", "seq-1")
+            await cp.checkpoint("shard-1", "seq-9")
+
+            with pytest.raises(CheckpointFlushError) as exc_info:
+                await cp.manual_checkpoint()
+
+            # Only shard-0 is in the error list; shard-1 was attempted after it.
+            assert [shard_id for shard_id, _ in exc_info.value.errors] == ["shard-0"]
+
+            # shard-0 stays buffered, shard-1 was flushed and popped. Without the
+            # continue-on-error fix, shard-1 would still be buffered here.
+            assert cp._manual_checkpoints == {"shard-0": "seq-1"}
+        finally:
+            await cp.close()
+
+        assert collector.counters[f"consumer_checkpoint_failure_total{{{_shard_labels('shard-0')}}}"] == 1
+        assert collector.counters[f"consumer_checkpoint_success_total{{{_shard_labels('shard-1')}}}"] == 1
+
+    @pytest.mark.asyncio
+    async def test_checkpoint_flush_error_message_and_cause(self):
+        """CheckpointFlushError lists every failing shard in its message, and
+        ``__cause__`` points at the first underlying exception for traceback."""
+        cp = await _make_redis_cp(auto_checkpoint=False)
+        cp.client.getset = AsyncMock(return_value=None)  # triggers NotImplementedError
+
+        try:
+            await cp.checkpoint("shard-0", "seq-1")
+            await cp.checkpoint("shard-1", "seq-9")
+
+            with pytest.raises(CheckpointFlushError) as exc_info:
+                await cp.manual_checkpoint()
+        finally:
+            await cp.close()
+
+        exc = exc_info.value
+        assert "2 shard(s) failed" in str(exc)
+        assert "shard-0" in str(exc) and "shard-1" in str(exc)
+        # __cause__ is the first collected exception (insertion order).
+        assert exc.__cause__ is exc.errors[0][1]
+        assert isinstance(exc.__cause__, NotImplementedError)
+
+    @pytest.mark.asyncio
+    async def test_manual_checkpoint_no_raise_on_all_success(self):
+        """Regression guard: when every flush succeeds, manual_checkpoint() must
+        not raise and must drain the buffer."""
+        cp = await _make_redis_cp(auto_checkpoint=False)
+
+        previous_val = '{"ref": "' + cp.get_ref() + '", "ts": 0, "sequence": "seq-prev"}'
+        cp.client.getset = AsyncMock(return_value=previous_val)
+
+        try:
+            await cp.checkpoint("shard-0", "seq-1")
+            await cp.checkpoint("shard-1", "seq-9")
+
+            await cp.manual_checkpoint()  # must not raise
+
+            assert cp._manual_checkpoints == {}
+        finally:
+            await cp.close()
+
+    @pytest.mark.asyncio
     async def test_manual_checkpoint_flush_retries_remaining_on_next_call(self):
-        """After a flush fails mid-loop, a subsequent manual_checkpoint() call
-        re-attempts the entries that were left in the buffer."""
+        """After a flush leaves a failing shard buffered, a subsequent
+        manual_checkpoint() call re-attempts it."""
         collector = InMemoryMetricsCollector()
         cp = await _make_redis_cp(auto_checkpoint=False)
         cp.bind_metrics(collector, {"stream_name": "test-stream"})
 
         previous_val = '{"ref": "' + cp.get_ref() + '", "ts": 0, "sequence": "seq-prev"}'
-        # First flush: shard-0 raises. Second flush: both shards succeed.
+        # First flush: shard-0 raises, shard-1 succeeds. Second flush: shard-0 succeeds.
         cp.client.getset = AsyncMock(side_effect=[RuntimeError("flake"), previous_val, previous_val])
 
         try:
             await cp.checkpoint("shard-0", "seq-1")
             await cp.checkpoint("shard-1", "seq-9")
 
-            with pytest.raises(RuntimeError):
+            with pytest.raises(CheckpointFlushError):
                 await cp.manual_checkpoint()
-            assert set(cp._manual_checkpoints) == {"shard-0", "shard-1"}
+            # shard-1 was flushed in the same call (continue-on-error), only the
+            # failing shard stays buffered for retry.
+            assert set(cp._manual_checkpoints) == {"shard-0"}
 
             # Second flush drains the buffer.
             await cp.manual_checkpoint()


### PR DESCRIPTION
## Summary

`manual_checkpoint()` is now best-effort: every buffered shard is attempted on each call, per-shard failures are collected, and the call raises a new `CheckpointFlushError` at the end carrying the failures in `.errors`.

Previously a single failing shard at the head of `_manual_checkpoints` would block every shard behind it from ever being flushed. Dict iteration is insertion-ordered, so a shard with a repeatable failure (lost lease, persistent backend error, malformed sequence) would sit at the head forever: every subsequent flush retried it first, aborted on it, and never reached the healthy shards. Records on healthy shards were durable-write-starved until consumer restart (at-least-once semantics preserved records, but latency was unbounded).

Applies to both `RedisCheckPointer` and `DynamoDBCheckPointer`.

Fixes #79.

## What changed

- **Continue-on-error loop**: each buffered shard is attempted; failures are collected into a list, successes are popped (guarded by the value-match check from #77 so a concurrent `checkpoint()` buffering a newer sequence isn't silently dropped).
- **New `CheckpointFlushError`**: raised iff at least one shard failed. `.errors` is a `list[tuple[str, BaseException]]` in attempt order. `__cause__` is set to the first underlying exception so tracebacks show a real failure.
- Exported from the top-level `kinesis` package.

## Backwards compatibility

- Callers that caught the inner exception type directly (e.g. `except RuntimeError:`, `except ClientError:`) will no longer match: per-shard failures are wrapped in `CheckpointFlushError`. Catch `CheckpointFlushError` and inspect `.errors`, or broaden to `except Exception:` if the distinction doesn't matter. `CheckpointFlushError` subclasses `Exception`, so existing `except Exception:` clauses continue to work.
- Per-shard `consumer_checkpoint_success_total` / `_failure_total` emissions are unchanged (still one per shard, emitted from inside `_checkpoint`).

## Test plan

- [x] `test_manual_checkpoint_continues_past_head_failure` (Redis + DynamoDB): poison-pill shard at head no longer blocks healthy shards behind it
- [x] `test_manual_checkpoint_collects_all_failures` (DynamoDB): `.errors` lists every failure in attempt order when every shard fails
- [x] `test_checkpoint_flush_error_message_and_cause`: exception message lists every failing shard; `__cause__` points at the first underlying exception
- [x] `test_manual_checkpoint_no_raise_on_all_success`: happy path still doesn't raise
- [x] Existing mid-loop-failure tests updated to expect `CheckpointFlushError` and assert `.errors` shape
- [x] Full non-Docker suite: `pytest -m "not dynamodb and not aws"` -> 225 passed, 12 skipped
- [x] `black --check` + `flake8` clean on touched files
- [x] Codex + Gemini external review: no findings on correctness, exception chaining, or poison-pill coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Checkpoint flush operations now use best-effort flushing: all buffered shards are attempted, failures are collected, and reported together in a new `CheckpointFlushError` exception containing all per-shard errors instead of failing on the first error.

* **Documentation**
  * Updated changelog with backwards-compatibility guidance for applications catching per-shard exceptions directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->