### PR TITLE
chore(ci/test): bump Floci to 1.5.4, retire kinesalite, enable ARN test

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
 
     services:
       kinesis:
-        image: hectorvent/floci:1.4.0
+        image: hectorvent/floci:1.5.4
         ports:
           - 4566:4566
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
 
     services:
       kinesis:
-        image: hectorvent/floci:1.4.0
+        image: hectorvent/floci:1.5.4
         ports:
           - 4566:4566
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,13 @@
 - Removed `Consumer._checkpoint_with_metrics` (private, added in v2.5.0).
   Callers invoke `checkpointer.checkpoint()` directly; emission now lives
   on `BaseCheckPointer` via `_emit_checkpoint_success` / `_emit_checkpoint_failure`.
+- CI and local docker-compose now run Floci 1.5.4 (was: Floci 1.4.0 in CI,
+  kinesalite in docker-compose). Local dev port is 4566 (was 4567 for kinesalite).
+  Re-enables the `test_producer_consumer_with_stream_arn` integration test
+  (Floci 1.5.2+ resolves stream names from `StreamARN`) and the
+  `consumer_iterator_age_milliseconds` assertion in
+  `test_consumer_metrics_round_trip` (Floci 1.5.4 returns time-based
+  `MillisBehindLatest`). No runtime behaviour change for library consumers.
 - Added `BaseCheckPointer.bind_metrics(collector, labels)` so Consumer can inject
   its `stream_name` label into the checkpointer's emissions at construction time.
   Intentionally not added to the `CheckPointer` Protocol to avoid breaking static

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ async-kinesis tail my-stream -i TRIM_HORIZON -f json -n 5
 
 | Option | Env Var | Description |
 | --- | --- | --- |
-| `--endpoint-url` | `ENDPOINT_URL` | Kinesis endpoint (for LocalStack/kinesalite) |
+| `--endpoint-url` | `ENDPOINT_URL` | Kinesis endpoint (for LocalStack/Floci) |
 | `--region` | `AWS_DEFAULT_REGION` | AWS region |
 | `-v, --verbose` | | Enable debug logging |
 
@@ -652,7 +652,7 @@ with patch("myapp.Producer", MockProducer):
 
 ### Local Testing
 
-Uses kinesalite (Docker Compose) and Floci (CI) for integration testing:
+Uses Floci for integration testing (Docker Compose and CI):
 
 ```bash
 # Run full test suite via Docker

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,11 +1,10 @@
 services:
 
   kinesis:
-    image: instructure/kinesalite:latest
-    command: --port 4567 --shardLimit 10000
+    image: hectorvent/floci:1.5.4
     restart: always
     ports:
-      - 4567:4567
+      - 4566:4566
   redis:
     image: redis:latest
     restart: always
@@ -24,7 +23,7 @@ services:
        dockerfile: Dockerfile
      environment:
       - AWS_DEFAULT_REGION=ap-southeast-2
-      - ENDPOINT_URL=http://kinesis:4567
+      - ENDPOINT_URL=http://kinesis:4566
       - REDIS_HOST=redis
       - REDIS_PORT=6379
       - AWS_ACCESS_KEY_ID=test

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -18,7 +18,7 @@ async-kinesis [OPTIONS] COMMAND [ARGS]...
 
 | Option | Env Var | Description |
 | --- | --- | --- |
-| `--endpoint-url` | `ENDPOINT_URL` | Kinesis endpoint URL (for LocalStack, kinesalite, etc.) |
+| `--endpoint-url` | `ENDPOINT_URL` | Kinesis endpoint URL (for LocalStack, Floci, etc.) |
 | `--region` | `AWS_DEFAULT_REGION` | AWS region name |
 | `-v, --verbose` | | Enable debug logging (shows library internals) |
 | `--version` | | Show version and exit |
@@ -39,7 +39,7 @@ async-kinesis list [--limit N]
 | --- | --- | --- |
 | `--limit` | 100 | Maximum number of streams to return |
 
-Handles both AWS (StreamSummaries with status/shard count/mode) and kinesalite (StreamNames-only) response formats.
+Handles both AWS (StreamSummaries with status/shard count/mode) and emulator (StreamNames-only) response formats.
 
 **Example:**
 ```
@@ -155,10 +155,10 @@ seq 5 | jq -c '{n: .}' | async-kinesis put my-stream
 async-kinesis put my-stream "plain text message" -p string
 ```
 
-## LocalStack / Kinesalite Usage
+## LocalStack / Floci Usage
 
 ```bash
-export ENDPOINT_URL=http://localhost:4566    # LocalStack
+export ENDPOINT_URL=http://localhost:4566    # LocalStack or Floci
 export AWS_DEFAULT_REGION=ap-southeast-2
 export AWS_ACCESS_KEY_ID=test
 export AWS_SECRET_ACCESS_KEY=test
@@ -171,5 +171,5 @@ async-kinesis tail test-stream -i TRIM_HORIZON -n 1
 Or pass the endpoint directly:
 
 ```bash
-async-kinesis --endpoint-url http://localhost:4567 list
+async-kinesis --endpoint-url http://localhost:4566 list
 ```

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -293,14 +293,14 @@ Extra parameter: `poll_delay` (default `0`) — seconds between poll cycles when
 
 Replace infrastructure-dependent test setup with in-memory mocks:
 
-**Before (Docker + kinesalite):**
+**Before (Docker + emulator):**
 
 ```python
 @pytest_asyncio.fixture
 async def producer(random_stream_name):
     async with Producer(
         stream_name=random_stream_name,
-        endpoint_url="http://localhost:4567",
+        endpoint_url="http://localhost:4566",
         region_name="ap-southeast-2",
         create_stream=True,
     ) as prod:

--- a/kinesis/cli/stream.py
+++ b/kinesis/cli/stream.py
@@ -94,7 +94,7 @@ async def list_streams(ctx, limit):
     async with _ClientHelper(endpoint_url=endpoint_url, region_name=region) as helper:
         response = await helper.client.list_streams(Limit=limit)
 
-        # AWS returns StreamSummaries; kinesalite returns only StreamNames
+        # AWS returns StreamSummaries; emulators (Floci, kinesalite) return only StreamNames
         summaries = response.get("StreamSummaries")
         if summaries is not None:
             if not summaries:
@@ -118,7 +118,7 @@ async def list_streams(ctx, limit):
             if not names:
                 click.echo("No streams found.")
                 return
-            # Kinesalite / basic: just names, fetch details per stream
+            # Emulator fallback (names only): fetch details per stream
             headers = ["Name", "Status", "Shards"]
             rows = []
             for name in names:

--- a/tests.py
+++ b/tests.py
@@ -39,10 +39,8 @@ log = logging.getLogger(__name__)
 
 load_dotenv()
 
-# https://github.com/mhart/kinesalite
-# ./node_modules/.bin/kinesalite --shardLimit 1000
-# see also docker-compose.yaml
-ENDPOINT_URL = os.environ.get("ENDPOINT_URL", "http://localhost:4567")
+# See docker-compose.yaml for the Floci service used as the test backend.
+ENDPOINT_URL = os.environ.get("ENDPOINT_URL", "http://localhost:4566")
 
 TESTING_USE_AWS_KINESIS = os.environ.get("TESTING_USE_AWS_KINESIS", "0") == "1"
 
@@ -524,7 +522,7 @@ class CheckpointTests(BaseKinesisTests):
 
 class KinesisTests(BaseKinesisTests):
     """
-    Kinesalite Tests
+    Tests against the Floci Kinesis emulator.
     """
 
     async def test_stream_does_not_exist(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,7 @@ from kinesis.testing import kinesis_backend, kinesis_consumer, kinesis_producer,
 load_dotenv()
 
 # Test configuration
-ENDPOINT_URL = os.environ.get("ENDPOINT_URL", "http://localhost:4567")
+ENDPOINT_URL = os.environ.get("ENDPOINT_URL", "http://localhost:4566")
 TESTING_USE_AWS_KINESIS = os.environ.get("TESTING_USE_AWS_KINESIS", "0") == "1"
 
 # Set up Redis port for docker-compose
@@ -44,7 +44,7 @@ _docker_available_cache = None
 
 
 def _is_endpoint_reachable(url):
-    """Check if the Docker test endpoint (kinesalite/localstack) is reachable."""
+    """Check if the Docker test endpoint (Floci/LocalStack) is reachable."""
     try:
         parsed = urlparse(url)
         if not parsed.hostname or not parsed.port:
@@ -105,7 +105,7 @@ async def test_stream(random_stream_name, endpoint_url):
     yield random_stream_name
 
     # Cleanup would go here if needed
-    # For now, kinesalite doesn't persist between runs
+    # For now, Floci doesn't persist between runs
 
 
 @pytest_asyncio.fixture
@@ -161,7 +161,7 @@ def _make_mock_consumer(**kwargs):
     """Create a Consumer with mocked internals for unit testing (no Docker)."""
     defaults = {
         "stream_name": "test-stream",
-        "endpoint_url": "http://localhost:4567",
+        "endpoint_url": "http://localhost:4566",
         "skip_describe_stream": True,
         "idle_timeout": 0.5,
     }

--- a/tests/resharding/test_resharding_in_progress.py
+++ b/tests/resharding/test_resharding_in_progress.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 class ReshardingInProgressTest:
     """Test resharding scenarios when operations are in progress"""
 
-    def __init__(self, endpoint_url="http://localhost:4567"):
+    def __init__(self, endpoint_url="http://localhost:4566"):
         self.endpoint_url = endpoint_url
         self.test_streams = []
 

--- a/tests/resharding/test_resharding_integration.py
+++ b/tests/resharding/test_resharding_integration.py
@@ -2,7 +2,7 @@
 """
 Resharding Integration Test
 
-Tests resharding behavior using LocalStack with actual stream creation and consumption.
+Tests resharding behavior using Floci with actual stream creation and consumption.
 This simulates resharding by creating streams with different shard counts and testing
 our consumer's ability to handle the topology correctly.
 """
@@ -27,9 +27,9 @@ logger = logging.getLogger(__name__)
 
 
 class ReshardingIntegrationTest:
-    """Integration test for resharding scenarios using LocalStack"""
+    """Integration test for resharding scenarios using Floci"""
 
-    def __init__(self, endpoint_url="http://localhost:4567"):
+    def __init__(self, endpoint_url="http://localhost:4566"):
         self.endpoint_url = endpoint_url
         self.test_streams = []
 
@@ -364,14 +364,14 @@ async def main():
 
 
 if __name__ == "__main__":
-    # Check if LocalStack is available
+    # Check if the Kinesis emulator (Floci) is available
     try:
         import urllib.request
 
-        urllib.request.urlopen("http://localhost:4566/_localstack/health", timeout=2)
-        print("✅ LocalStack detected, running integration tests...")
+        urllib.request.urlopen("http://localhost:4566/", timeout=2)
+        print("✅ Floci detected, running integration tests...")
     except Exception:
-        print("⚠️ LocalStack not available. Start with: docker-compose up kinesis")
+        print("⚠️ Floci not available. Start with: docker-compose up kinesis")
         print("   Running tests anyway (may fail)...")
 
     success = asyncio.run(main())

--- a/tests/resharding/test_start_during_resharding.py
+++ b/tests/resharding/test_start_during_resharding.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 class StartDuringReshardingTest:
     """Test starting operations during active resharding"""
 
-    def __init__(self, endpoint_url="http://localhost:4567"):
+    def __init__(self, endpoint_url="http://localhost:4566"):
         self.endpoint_url = endpoint_url
         self.test_streams = []
 

--- a/tests/test_checkpoint_ordering.py
+++ b/tests/test_checkpoint_ordering.py
@@ -463,7 +463,7 @@ class TestCheckpointInterval:
         with pytest.raises(ValueError, match="mutually exclusive"):
             Consumer(
                 stream_name="test-stream",
-                endpoint_url="http://localhost:4567",
+                endpoint_url="http://localhost:4566",
                 skip_describe_stream=True,
                 checkpoint_interval=5.0,
                 checkpointer=AsyncMock(auto_checkpoint=False),

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -107,15 +107,8 @@ class TestConsumer:
         assert sum(collector.counters[k] for k in bytes_keys) == 3 * expected_per_record
         assert queue_keys
 
-        # Iterator age: only assert if the backend reported MillisBehindLatest as
-        # proper milliseconds. Floci < 1.6 (approx) populates the field with a
-        # record count, not an age, so skip this assertion until CI pins a patched image.
         iterator_age_keys = [k for k in collector.gauges if k.startswith("consumer_iterator_age_milliseconds")]
-        if not iterator_age_keys:
-            pytest.skip(
-                "Backend did not report MillisBehindLatest with millisecond semantics "
-                "(e.g. kinesalite omits it; floci PR #444 not yet released)."
-            )
+        assert iterator_age_keys, f"expected consumer_iterator_age_milliseconds, got {list(collector.gauges)}"
         assert all(collector.gauges[k] >= 0 for k in iterator_age_keys)
 
     @pytest.mark.asyncio

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -439,11 +439,6 @@ class TestIntegration:
     @pytest.mark.asyncio
     async def test_producer_consumer_with_stream_arn(self, random_stream_name, endpoint_url):
         """Test producer and consumer with stream ARN instead of name (PR #39)."""
-        # Skip for local emulators as they may not support ARN addressing
-        if any(host in endpoint_url for host in ["localhost", "kinesis:", "localstack"]):
-            pytest.skip("Local emulator does not support ARN addressing")
-
-        # Create a mock ARN for the stream
         stream_arn = f"arn:aws:kinesis:us-east-1:123456789012:stream/{random_stream_name}"
 
         test_messages = [{"arn_test": i, "message": f"arn-message-{i}"} for i in range(3)]
@@ -458,37 +453,32 @@ class TestIntegration:
             pass  # Just create the stream
 
         # Now produce using ARN
-        try:
-            async with Producer(
-                stream_name=stream_arn,
-                endpoint_url=endpoint_url,
-                create_stream=False,  # Don't try to create with ARN
-            ) as producer:
-                for message in test_messages:
-                    await producer.put(message)
-                await producer.flush()
+        async with Producer(
+            stream_name=stream_arn,
+            endpoint_url=endpoint_url,
+            create_stream=False,  # Don't try to create with ARN
+        ) as producer:
+            for message in test_messages:
+                await producer.put(message)
+            await producer.flush()
 
-            # Consume using ARN
-            consumed_messages = []
-            async with Consumer(
-                stream_name=stream_arn,
-                endpoint_url=endpoint_url,
-                sleep_time_no_records=0.1,
-            ) as consumer:
-                try:
-                    async with timeout(5):
-                        async for message in consumer:
-                            consumed_messages.append(message)
-                            if len(consumed_messages) >= len(test_messages):
-                                break
-                except asyncio.TimeoutError:
-                    pass
+        # Consume using ARN
+        consumed_messages = []
+        async with Consumer(
+            stream_name=stream_arn,
+            endpoint_url=endpoint_url,
+            sleep_time_no_records=0.1,
+        ) as consumer:
+            try:
+                async with timeout(5):
+                    async for message in consumer:
+                        consumed_messages.append(message)
+                        if len(consumed_messages) >= len(test_messages):
+                            break
+            except asyncio.TimeoutError:
+                pass
 
-            assert len(consumed_messages) >= len(test_messages)
-
-        except Exception as e:
-            # ARN support might not work with LocalStack/testing environment
-            pytest.skip(f"ARN support test failed: {e}")
+        assert len(consumed_messages) >= len(test_messages)
 
     @pytest.mark.asyncio
     async def test_stream_arn_validation(self, endpoint_url):

--- a/tests/test_metrics_unit.py
+++ b/tests/test_metrics_unit.py
@@ -312,7 +312,7 @@ class TestConsumerFetchEmits:
 
     @pytest.mark.asyncio
     async def test_fetch_skips_iterator_age_when_field_absent(self, mock_consumer):
-        """Kinesalite / unpatched floci omit MillisBehindLatest. Emit must no-op."""
+        """Backends that omit MillisBehindLatest must no-op (no iterator_age emission)."""
         collector = InMemoryMetricsCollector()
         consumer = mock_consumer(metrics_collector=collector)
         consumer.checkpointer = MemoryCheckPointer(name="test")

--- a/tests/test_producer.py
+++ b/tests/test_producer.py
@@ -700,7 +700,7 @@ class TestProducerFlushLifecycle:
         """Create a Producer with mocked Kinesis client for unit testing."""
         defaults = {
             "stream_name": "test-stream",
-            "endpoint_url": "http://localhost:4567",
+            "endpoint_url": "http://localhost:4566",
             "skip_describe_stream": True,
             "buffer_time": 10,
         }

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -186,7 +186,7 @@ class TestMockProducer:
         MockKinesisBackend.create_stream("test")
         async with MockProducer(
             stream_name="test",
-            endpoint_url="http://localhost:4567",
+            endpoint_url="http://localhost:4566",
             region_name="us-east-1",
             buffer_time=1.0,
             put_rate_limit_per_shard=500,
@@ -312,7 +312,7 @@ class TestMockConsumer:
         stream.seal()
         async with MockConsumer(
             stream_name="test",
-            endpoint_url="http://localhost:4567",
+            endpoint_url="http://localhost:4566",
             region_name="us-east-1",
             max_queue_size=5000,
             sleep_time_no_records=5,


### PR DESCRIPTION
## Summary

- CI and local docker-compose now use Floci 1.5.4 as the Kinesis emulator. Kinesalite (dead since 2020, no StreamARN / on-demand / MillisBehindLatest / RegisterStreamConsumer support) is retired.
- Re-enables `test_producer_consumer_with_stream_arn` (Floci 1.5.2+ resolves stream name from `StreamARN`, upstream [floci-io/floci#304](https://github.com/floci-io/floci/pull/304)).
- Re-enables the iterator-age assertion in `test_consumer_metrics_round_trip` (Floci 1.5.4 returns time-based `MillisBehindLatest`, upstream [floci-io/floci#444](https://github.com/floci-io/floci/pull/444)).
- Local dev port moved from 4567 (kinesalite) to 4566 (Floci). Matches CI.

## Changes

- `.github/workflows/{test,publish}.yml`: `hectorvent/floci:1.4.0` -> `1.5.4`
- `docker-compose.yaml`: `instructure/kinesalite:latest` -> `hectorvent/floci:1.5.4`, port 4567 -> 4566
- `tests/test_integration.py`: drop emulator skip + broad-except fallback in the ARN test
- `tests/test_consumer.py`: drop iterator-age skip, assert field is populated
- `tests/conftest.py`, `tests.py`, `tests/test_*.py`, `tests/resharding/*`: sweep remaining `localhost:4567` defaults to `:4566`
- `kinesis/cli/stream.py`, `docs/cli.md`, `docs/testing.md`, `README.md`, `CHANGELOG.md`: docs / comments updated for the new backend

Unit-level coverage for backends that omit `MillisBehindLatest` remains in `tests/test_metrics_unit.py::test_fetch_skips_iterator_age_when_field_absent`, so library robustness is unchanged.

## Backwards compatibility

- **No runtime behaviour change for library consumers.** All changes are scoped to test infrastructure and documentation.
- **Local development**: if you run `docker compose up`, the Kinesis emulator port moves from `4567` to `4566`. Update any local `.env` / shell aliases that pin `ENDPOINT_URL=http://localhost:4567`.
- CI test matrix unchanged (Python 3.10 - 3.14).

## Test plan

- [x] `test_producer_consumer_with_stream_arn` passes against Floci 1.5.4 (no skip)
- [x] `test_consumer_metrics_round_trip` asserts `consumer_iterator_age_milliseconds` without skip
- [x] Full suite `pytest -m "not dynamodb"`: 228 passed, 6 skipped (pre-existing AWS/KPL/msgpack), 24 deselected
- [x] `black --check`, `isort --check-only`, `flake8` all clean
- [x] Verified Floci 1.5.4 `ListStreams` returns `StreamNames`-only (emulator fallback in `kinesis/cli/stream.py` still needed, comment generalized)
- [ ] CI matrix across Python 3.10 - 3.14 stays green on Floci 1.5.4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded Kinesis emulator dependency to Floci 1.5.4
  * Updated local development endpoint port configuration from 4567 to 4566

* **Documentation**
  * Updated local testing guides and CLI documentation to reference Floci instead of kinesalite
  * Updated example endpoint URLs to reflect new port mapping

* **Tests**
  * Re-enabled integration test assertions compatible with updated emulator version

<!-- end of auto-generated comment: release notes by coderabbit.ai -->