### PR TITLE
refactor(checkpointer): lift checkpoint()/manual_checkpoint() to base class (#82)

### DIFF
--- a/kinesis/checkpointers.py
+++ b/kinesis/checkpointers.py
@@ -181,7 +181,7 @@ class BaseHeartbeatCheckPointer(BaseCheckPointer):
         self.session_timeout = session_timeout
         self.heartbeat_frequency = heartbeat_frequency
         self.auto_checkpoint = auto_checkpoint
-        self._manual_checkpoints = {}
+        self._manual_checkpoints: Dict[str, str] = {}
 
         self.heartbeat_task = asyncio.Task(self.heartbeat())
 
@@ -201,6 +201,57 @@ class BaseHeartbeatCheckPointer(BaseCheckPointer):
                 val = {"ref": self.get_ref(), "ts": self.get_ts(), "sequence": sequence}
                 log.debug("Heartbeating {}@{}".format(shard_id, sequence))
                 await self.do_heartbeat(key, val)
+
+    async def _checkpoint(self, shard_id: str, sequence: str) -> None:
+        """Backend-specific checkpoint write. Subclasses must override."""
+        raise NotImplementedError
+
+    async def checkpoint(self, shard_id: str, sequence: str) -> None:
+        """Record progress for a shard.
+
+        If ``auto_checkpoint`` is False the (shard_id, sequence) pair is
+        buffered in ``_manual_checkpoints`` and flushed lazily by
+        ``manual_checkpoint()``. Otherwise the call drives ``_checkpoint``
+        directly, which performs the backend write and emits per-shard
+        success/failure metrics.
+        """
+        if not self.auto_checkpoint:
+            log.debug(f"{self.get_ref()} updated manual checkpoint {shard_id}@{sequence}")
+            self._manual_checkpoints[shard_id] = sequence
+            return
+
+        await self._checkpoint(shard_id, sequence)
+
+    async def manual_checkpoint(self) -> None:
+        """Flush all buffered manual checkpoints, best-effort.
+
+        Every buffered shard is attempted on each call. A shard whose flush
+        raises is left in the buffer (so a poison-pill shard does not block
+        the shards behind it from ever being flushed); shards that succeed
+        are popped. The success-path pop is guarded by a value-match check,
+        so a concurrent ``checkpoint()`` that buffered a newer sequence for
+        the same shard mid-flight is not silently dropped.
+
+        Raises:
+            CheckpointFlushError: if one or more shards raised. The compound
+                exception carries the per-shard failures in ``.errors``.
+                Per-shard ``consumer_checkpoint_failure_total`` counters are
+                emitted from inside ``_checkpoint`` as each flush fails, so
+                callers should monitor that metric for alerting rather than
+                parsing the exception.
+        """
+        errors: List[Tuple[str, BaseException]] = []
+        for shard_id in list(self._manual_checkpoints):
+            sequence = self._manual_checkpoints[shard_id]
+            try:
+                await self._checkpoint(shard_id, sequence)
+            except Exception as exc:
+                errors.append((shard_id, exc))
+                continue
+            if self._manual_checkpoints.get(shard_id) == sequence:
+                self._manual_checkpoints.pop(shard_id, None)
+        if errors:
+            raise CheckpointFlushError(errors) from errors[0][1]
 
 
 class MemoryCheckPointer(BaseCheckPointer):
@@ -278,46 +329,6 @@ class RedisCheckPointer(BaseHeartbeatCheckPointer):
 
     def get_ts(self):
         return round(int(datetime.now(tz=timezone.utc).timestamp()))
-
-    async def checkpoint(self, shard_id, sequence):
-
-        if not self.auto_checkpoint:
-            log.debug("{} updated manual checkpoint {}@{}".format(self.get_ref(), shard_id, sequence))
-            self._manual_checkpoints[shard_id] = sequence
-            return
-
-        await self._checkpoint(shard_id, sequence)
-
-    async def manual_checkpoint(self):
-        """Flush all buffered manual checkpoints, best-effort.
-
-        Every buffered shard is attempted on each call. A shard whose flush
-        raises is left in the buffer (so a poison-pill shard does not block
-        the shards behind it from ever being flushed); shards that succeed
-        are popped. The success-path pop is guarded by a value-match check,
-        so a concurrent ``checkpoint()`` that buffered a newer sequence for
-        the same shard mid-flight is not silently dropped.
-
-        Raises:
-            CheckpointFlushError: if one or more shards raised. The compound
-                exception carries the per-shard failures in ``.errors``.
-                Per-shard ``consumer_checkpoint_failure_total`` counters are
-                emitted from inside ``_checkpoint`` as each flush fails, so
-                callers should monitor that metric for alerting rather than
-                parsing the exception.
-        """
-        errors: List[Tuple[str, BaseException]] = []
-        for shard_id in list(self._manual_checkpoints):
-            sequence = self._manual_checkpoints[shard_id]
-            try:
-                await self._checkpoint(shard_id, sequence)
-            except Exception as exc:
-                errors.append((shard_id, exc))
-                continue
-            if self._manual_checkpoints.get(shard_id) == sequence:
-                self._manual_checkpoints.pop(shard_id, None)
-        if errors:
-            raise CheckpointFlushError(errors) from errors[0][1]
 
     async def _checkpoint(self, shard_id, sequence):
         try:

--- a/kinesis/dynamodb.py
+++ b/kinesis/dynamodb.py
@@ -8,9 +8,9 @@ import asyncio
 import logging
 import os
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, Optional, Tuple, Union
 
-from .checkpointers import BaseHeartbeatCheckPointer, CheckpointFlushError
+from .checkpointers import BaseHeartbeatCheckPointer
 
 log = logging.getLogger(__name__)
 
@@ -208,46 +208,6 @@ class DynamoDBCheckPointer(BaseHeartbeatCheckPointer):
                     log.warning(f"Lost ownership of shard {key} during heartbeat")
                 else:
                     raise
-
-    async def checkpoint(self, shard_id: str, sequence: str) -> None:
-        """Checkpoint progress for a shard."""
-        if not self.auto_checkpoint:
-            log.debug(f"{self.get_ref()} updated manual checkpoint {shard_id}@{sequence}")
-            self._manual_checkpoints[shard_id] = sequence
-            return
-
-        await self._checkpoint(shard_id, sequence)
-
-    async def manual_checkpoint(self) -> None:
-        """Flush all buffered manual checkpoints to DynamoDB, best-effort.
-
-        Every buffered shard is attempted on each call. A shard whose flush
-        raises is left in the buffer (so a poison-pill shard does not block
-        the shards behind it from ever being flushed); shards that succeed
-        are popped. The success-path pop is guarded by a value-match check,
-        so a concurrent ``checkpoint()`` that buffered a newer sequence for
-        the same shard mid-flight is not silently dropped.
-
-        Raises:
-            CheckpointFlushError: if one or more shards raised. The compound
-                exception carries the per-shard failures in ``.errors``.
-                Per-shard ``consumer_checkpoint_failure_total`` counters are
-                emitted from inside ``_checkpoint`` as each flush fails, so
-                callers should monitor that metric for alerting rather than
-                parsing the exception.
-        """
-        errors: List[Tuple[str, BaseException]] = []
-        for shard_id in list(self._manual_checkpoints):
-            sequence = self._manual_checkpoints[shard_id]
-            try:
-                await self._checkpoint(shard_id, sequence)
-            except Exception as exc:
-                errors.append((shard_id, exc))
-                continue
-            if self._manual_checkpoints.get(shard_id) == sequence:
-                self._manual_checkpoints.pop(shard_id, None)
-        if errors:
-            raise CheckpointFlushError(errors) from errors[0][1]
 
     async def _checkpoint(self, shard_id: str, sequence: str) -> None:
         """Internal checkpoint implementation."""

--- a/tests/test_checkpoint_base_contract.py
+++ b/tests/test_checkpoint_base_contract.py
@@ -1,0 +1,186 @@
+"""Base-class contract tests for BaseHeartbeatCheckPointer.
+
+Proves that checkpoint() / manual_checkpoint() behave identically regardless
+of backend. Each test drives a minimal fake subclass whose _checkpoint is a
+controllable in-memory write with an opt-in failure map. If both concrete
+backends (Redis, DynamoDB) inherit these methods unchanged, the contract
+guaranteed by these tests is what they provide.
+
+Covers the five cases from PLAN_ISSUE_82:
+  1. auto_checkpoint=False buffers without writing.
+  2. Successful flush pops only entries whose buffered sequence still matches.
+  3. Failed flush leaves the offending shard in _manual_checkpoints.
+  4. Mixed success/failure raises CheckpointFlushError listing every failure,
+     __cause__ = first failure.
+  5. Concurrent checkpoint() buffering a newer sequence mid-flush is retained.
+"""
+
+import asyncio
+from typing import Dict, Optional, Set
+
+import pytest
+
+from kinesis.checkpointers import BaseHeartbeatCheckPointer, CheckpointFlushError
+
+
+class FakeHeartbeatCheckPointer(BaseHeartbeatCheckPointer):
+    """Minimal BaseHeartbeatCheckPointer subclass for contract tests.
+
+    _checkpoint writes to an in-memory dict. A per-shard failure set forces
+    _checkpoint to raise for those shards, simulating a backend write error.
+    Heartbeat is effectively disabled (interval well beyond any test
+    duration); the task is cancelled in stop().
+
+    `mid_flush_hook` is an optional async callable invoked inside each
+    _checkpoint call before the write lands, used by the concurrency test
+    to inject a newer buffered sequence mid-flush.
+    """
+
+    def __init__(self, auto_checkpoint: bool = True):
+        super().__init__(
+            name="fake",
+            id="test",
+            heartbeat_frequency=3600,
+            auto_checkpoint=auto_checkpoint,
+        )
+        self.writes: Dict[str, str] = {}
+        self.failures: Set[str] = set()
+        self.mid_flush_hook = None
+
+    async def stop(self) -> None:
+        self.heartbeat_task.cancel()
+        try:
+            await self.heartbeat_task
+        except asyncio.CancelledError:
+            pass
+
+    def get_key(self, shard_id: str) -> str:
+        return shard_id
+
+    def get_ts(self) -> int:
+        return 0
+
+    async def do_heartbeat(self, key, value) -> None:
+        return None
+
+    async def allocate(self, shard_id: str):
+        self._items[shard_id] = None
+        return True, None
+
+    async def deallocate(self, shard_id: str) -> None:
+        self._items.pop(shard_id, None)
+
+    async def _checkpoint(self, shard_id: str, sequence: str) -> None:
+        try:
+            if self.mid_flush_hook is not None:
+                await self.mid_flush_hook(shard_id, sequence)
+            if shard_id in self.failures:
+                raise RuntimeError(f"forced failure for {shard_id}")
+            self.writes[shard_id] = sequence
+            self._items[shard_id] = sequence
+        except Exception:
+            self._emit_checkpoint_failure(shard_id)
+            raise
+        self._emit_checkpoint_success(shard_id)
+
+
+@pytest.fixture
+async def cp():
+    checkpointer = FakeHeartbeatCheckPointer(auto_checkpoint=False)
+    try:
+        yield checkpointer
+    finally:
+        await checkpointer.stop()
+
+
+@pytest.fixture
+async def auto_cp():
+    checkpointer = FakeHeartbeatCheckPointer(auto_checkpoint=True)
+    try:
+        yield checkpointer
+    finally:
+        await checkpointer.stop()
+
+
+class TestBaseCheckpointContract:
+    @pytest.mark.asyncio
+    async def test_auto_checkpoint_false_buffers_without_writing(self, cp):
+        """Case 1: buffered checkpoints never hit _checkpoint."""
+        await cp.checkpoint("shard-0", "seq-1")
+        await cp.checkpoint("shard-1", "seq-2")
+
+        assert cp.writes == {}
+        assert cp._manual_checkpoints == {"shard-0": "seq-1", "shard-1": "seq-2"}
+
+    @pytest.mark.asyncio
+    async def test_auto_checkpoint_true_writes_immediately(self, auto_cp):
+        """Contract companion to case 1: auto path drives _checkpoint."""
+        await auto_cp.checkpoint("shard-0", "seq-1")
+
+        assert auto_cp.writes == {"shard-0": "seq-1"}
+        assert auto_cp._manual_checkpoints == {}
+
+    @pytest.mark.asyncio
+    async def test_successful_flush_pops_all(self, cp):
+        """Case 2: a clean flush leaves no buffered entries."""
+        await cp.checkpoint("shard-0", "seq-1")
+        await cp.checkpoint("shard-1", "seq-2")
+
+        await cp.manual_checkpoint()
+
+        assert cp.writes == {"shard-0": "seq-1", "shard-1": "seq-2"}
+        assert cp._manual_checkpoints == {}
+
+    @pytest.mark.asyncio
+    async def test_failed_flush_retains_only_failing_shard(self, cp):
+        """Case 3: the offending shard stays buffered; peers are popped."""
+        await cp.checkpoint("shard-0", "seq-1")
+        await cp.checkpoint("shard-1", "seq-2")
+        await cp.checkpoint("shard-2", "seq-3")
+        cp.failures.add("shard-1")
+
+        with pytest.raises(CheckpointFlushError) as exc_info:
+            await cp.manual_checkpoint()
+
+        assert [sid for sid, _ in exc_info.value.errors] == ["shard-1"]
+        assert cp._manual_checkpoints == {"shard-1": "seq-2"}
+        assert cp.writes == {"shard-0": "seq-1", "shard-2": "seq-3"}
+
+    @pytest.mark.asyncio
+    async def test_mixed_failures_raise_compound_error(self, cp):
+        """Case 4: every failing shard listed in .errors, __cause__ = first."""
+        await cp.checkpoint("shard-0", "seq-1")
+        await cp.checkpoint("shard-1", "seq-2")
+        await cp.checkpoint("shard-2", "seq-3")
+        cp.failures.update({"shard-0", "shard-2"})
+
+        with pytest.raises(CheckpointFlushError) as exc_info:
+            await cp.manual_checkpoint()
+
+        failed_shards = [sid for sid, _ in exc_info.value.errors]
+        assert failed_shards == ["shard-0", "shard-2"]
+        assert exc_info.value.__cause__ is exc_info.value.errors[0][1]
+        assert cp._manual_checkpoints == {"shard-0": "seq-1", "shard-2": "seq-3"}
+        assert cp.writes == {"shard-1": "seq-2"}
+
+    @pytest.mark.asyncio
+    async def test_concurrent_newer_sequence_not_dropped(self, cp):
+        """Case 5: a newer sequence buffered mid-flush survives the pop.
+
+        checkpoint() running while manual_checkpoint() is awaiting _checkpoint
+        overwrites _manual_checkpoints[shard] with a newer sequence. The
+        value-match guard on the success-path pop must leave that newer
+        sequence in the buffer rather than dropping it.
+        """
+
+        async def inject_newer(shard_id: str, sequence: str) -> None:
+            if shard_id == "shard-0" and sequence == "seq-1":
+                cp._manual_checkpoints["shard-0"] = "seq-2"
+
+        await cp.checkpoint("shard-0", "seq-1")
+        cp.mid_flush_hook = inject_newer
+
+        await cp.manual_checkpoint()
+
+        assert cp._manual_checkpoints == {"shard-0": "seq-2"}
+        assert cp.writes == {"shard-0": "seq-1"}


### PR DESCRIPTION
Closes #82.

## Summary

Both `checkpoint()` and `manual_checkpoint()` carried logically identical bodies on `RedisCheckPointer` and `DynamoDBCheckPointer` (skin differences only: untyped Redis + `str.format()` vs typed DynamoDB + f-strings; docstring mentioning "to DynamoDB"). This PR moves the canonical implementation to `BaseHeartbeatCheckPointer` so future work (#80 concurrency, #81 papercuts) lands in one place.

Framed as pure dedupe with no semantic change, proven by new base-class contract tests.

## Changes

- `BaseHeartbeatCheckPointer` now owns `checkpoint()` + `manual_checkpoint()` with the typed DynamoDB signatures.
- `RedisCheckPointer` and `DynamoDBCheckPointer` inherit both methods verbatim; each retains its own `_checkpoint` (backend write).
- `_manual_checkpoints: Dict[str, str]` annotated on the base.
- New `tests/test_checkpoint_base_contract.py` exercises five invariants through a minimal `FakeHeartbeatCheckPointer` subclass, plus an auto-write companion case:
 1. `auto_checkpoint=False` buffers without writing.
 2. Clean flush pops every entry.
 3. Failed flush retains only the offending shard in `_manual_checkpoints`.
 4. Mixed success/failure raises `CheckpointFlushError` listing every failing shard; `__cause__` = first failure.
 5. Concurrent `checkpoint()` buffering a newer sequence mid-flush survives the pop (value-match guard).

Net diff: +236 / -83 (base gained the lifted bodies; both subclasses shrank; 6 new tests added).

## Backwards compatibility

- Method resolution is unchanged for callers: `instance.checkpoint(...)` and `instance.manual_checkpoint()` still dispatch the same code, just resolved one step up the MRO.
- External subclasses of `RedisCheckPointer` / `DynamoDBCheckPointer` that override either method keep working (MRO finds the override first).
- Two observable cosmetic changes:
 - Redis `checkpoint()` now carries type hints (`shard_id: str`, `sequence: str`). Strict type-checkers may flag callers that were passing non-str positionally.
 - The Redis `checkpoint()` log line now renders via f-string instead of `str.format()`. Rendered text is identical.

## Test plan

- [x] Non-docker suite: `pytest -v -m "not dynamodb and not integration"`, 160 passed, 7 skipped.
- [x] DynamoDB (mocked): `pytest -v -m dynamodb`, 26 passed.
- [x] Full docker compose: `docker compose up --abort-on-container-exit --exit-code-from test`, 237 passed, 6 skipped (covers Redis + local Kinesis integration paths that exercise `checkpoint()` through the lifted method).
- [x] New `tests/test_checkpoint_base_contract.py`, 6 passed.
- [x] Codex + Gemini focused reviews, no findings.

## Out of scope

- Concurrency fixes (issue #80), separate PR; cleaner after this.
- Papercuts (issue #81 C1/C2/C3), separate PR; also cleaner after this.
- Moving `_items` / `allocate` / `deallocate` up (differ per backend, per #82 non-goals).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code organization and type safety within the checkpointing system through consolidation of shared logic and explicit type annotations.

* **Tests**
  * Significantly expanded test coverage for checkpoint functionality, including validation of buffering behavior, flush operations, error handling, concurrent updates, and multi-shard failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->