### PR TITLE
Fix async heartbeat cleanup, iteration safety, and checkpoint validat…

### DIFF
--- a/kinesis/checkpointers.py
+++ b/kinesis/checkpointers.py
@@ -11,6 +11,9 @@ log = logging.getLogger(__name__)
 
 STANDALONE_STREAM_LABEL = "<standalone>"
 
+class CheckpointError(Exception):
+    pass
+
 
 class CheckpointFlushError(Exception):
     """Raised by ``manual_checkpoint()`` when one or more per-shard flushes fail.

--- a/kinesis/checkpointers.py
+++ b/kinesis/checkpointers.py
@@ -187,7 +187,12 @@ class BaseHeartbeatCheckPointer(BaseCheckPointer):
 
     async def close(self):
         log.debug("Cancelling heartbeat task..")
+
         self.heartbeat_task.cancel()
+        try:
+            await self.heartbeat_task
+        except asyncio.CancelledError:
+            pass
 
         await super().close()
 
@@ -196,7 +201,7 @@ class BaseHeartbeatCheckPointer(BaseCheckPointer):
             await asyncio.sleep(self.heartbeat_frequency)
 
             # todo: don't heartbeat if checkpoint already updated it recently
-            for shard_id, sequence in self._items.items():
+            for shard_id, sequence in list(self._items.items()):
                 key = self.get_key(shard_id)
                 val = {"ref": self.get_ref(), "ts": self.get_ts(), "sequence": sequence}
                 log.debug("Heartbeating {}@{}".format(shard_id, sequence))
@@ -329,13 +334,15 @@ class RedisCheckPointer(BaseHeartbeatCheckPointer):
             previous_val = json.loads(previous_val) if previous_val else None
 
             if not previous_val:
-                raise NotImplementedError(
+                raise CheckpointError(
                     "{} checkpointed on {} but key did not exist?".format(self.get_ref(), shard_id)
                 )
 
             if previous_val["ref"] != self.get_ref():
-                raise NotImplementedError(
-                    "{} checkpointed on {} but ref is different {}".format(self.get_ref(), shard_id, val["ref"])
+                raise CheckpointError(
+                    "{} checkpointed on {} but ref is different {}".format(
+                        self.get_ref(), shard_id, previous_val["ref"]
+                    )
                 )
 
             log.debug("{} checkpointed on {}@{}".format(self.get_ref(), shard_id, sequence))


### PR DESCRIPTION
Fix correctness issues in checkpointing system

- Properly await cancelled heartbeat task to avoid dangling async tasks
- Fix dictionary mutation during heartbeat iteration by snapshotting _items
- Replace incorrect NotImplementedError usage with CheckpointError in RedisCheckPointer
- Fix incorrect reference logging (previous_val["ref"] instead of val["ref"])

Fixes #81

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved graceful shutdown behavior for heartbeat monitoring tasks during service termination and cleanup
  * Fixed potential race condition that could occur when monitoring checkpoint items during concurrent heartbeat operations
  * Enhanced checkpoint validation error reporting with more specific and actionable error messages for better troubleshooting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->