### PR TITLE
docs: fix 9 accuracy issues across guides

### DIFF
--- a/docs/common-patterns.md
+++ b/docs/common-patterns.md
@@ -82,7 +82,13 @@ async def log_processor():
 
 ## Event Streaming
 
-Build event-driven architectures with multiple event types:
+Build event-driven architectures with multiple event types.
+
+> **Install note:** `MsgpackProcessor` requires the `msgpack` extra. Install
+> with `pip install async-kinesis[msgpack]`. Without it, the import succeeds
+> (the missing dependency is swallowed in `kinesis/serializers.py`), but the
+> first call to `producer.put()` or consumer iteration raises `NameError:
+> name 'msgpack' is not defined`.
 
 ```python
 import logging
@@ -175,14 +181,23 @@ async def handle_payment_processed(data):
 
 ## IoT Data Collection
 
-Collect and process high-volume IoT sensor data:
+Collect and process high-volume IoT sensor data.
+
+> **Processor choice:** This example uses `JsonProcessor` so each record can
+> carry its own `partition_key`. Records with the same `sensor_id` will hash
+> to the same shard (preserving per-sensor ordering); different sensor IDs
+> may share a shard depending on hash distribution. For higher throughput at
+> the cost of per-record routing, consider `KPLJsonProcessor`
+> (install with `pip install async-kinesis[kpl]`); note KPL aggregation does
+> **not** support custom `partition_key` on `producer.put()`, all records in an
+> aggregated batch share the batch's partition key.
 
 ```python
 import asyncio
 import logging
 import random
 from datetime import datetime
-from kinesis import Producer, Consumer, KPLJsonProcessor
+from kinesis import Producer, Consumer, JsonProcessor
 
 # Set up logging
 logger = logging.getLogger(__name__)
@@ -191,7 +206,10 @@ logger = logging.getLogger(__name__)
 async def iot_sensors():
     async with Producer(
         stream_name="iot-sensor-data",
-        processor=KPLJsonProcessor(),  # KPL aggregation for high volume
+        # JsonProcessor (SimpleAggregator) supports custom partition keys.
+        # KPLJsonProcessor would aggregate more efficiently but does NOT
+        # accept a custom partition_key (KPLAggregator.add_item() raises).
+        processor=JsonProcessor(),
         put_rate_limit_per_shard=500,  # Conservative rate to avoid throttling
         create_stream=True,
         create_stream_shards=4  # Multiple shards for parallel processing
@@ -228,7 +246,7 @@ async def iot_processor():
 
     async with Consumer(
         stream_name="iot-sensor-data",
-        processor=KPLJsonProcessor(),
+        processor=JsonProcessor(),  # Must match the producer's processor
         max_shard_consumers=4  # Process all shards in parallel
     ) as consumer:
 
@@ -570,7 +588,14 @@ class StreamMonitor:
             last_report = time.time()
 
             while True:
-                # Get shard status
+                # Get shard status. Fields available:
+                #   total_shards, active_shards, closed_shards, allocated_shards,
+                #   parent_shards, child_shards, exhausted_parents, expired_parents,
+                #   resharding_in_progress, topology, shard_details
+                # Lag is not in this dict. The consumer emits
+                # MetricType.CONSUMER_ITERATOR_AGE (millis behind) to a configured
+                # metrics_collector; CloudWatch also exposes
+                # GetRecords.IteratorAgeMilliseconds on the stream.
                 status = consumer.get_shard_status()
 
                 # Log shard health
@@ -578,17 +603,22 @@ class StreamMonitor:
                 logger.info(f"Total shards: {status['total_shards']}")
                 logger.info(f"Active shards: {status['active_shards']}")
                 logger.info(f"Closed shards: {status['closed_shards']}")
-                logger.info(f"Behind shards: {status.get('behind_shards', 0)}")
+                logger.info(f"Allocated to this consumer: {status['allocated_shards']}")
 
                 # Check for resharding
-                if status['parent_shards'] > 0:
-                    logger.warning(f"Resharding detected! Parent shards: {status['parent_shards']}")
+                if status['resharding_in_progress'] or status['parent_shards'] > 0:
+                    logger.warning(
+                        f"Resharding in progress. Parents: {status['parent_shards']}, "
+                        f"children: {status['child_shards']}, "
+                        f"expired parents: {status['expired_parents']}"
+                    )
 
-                # Monitor consumer lag
+                # Per-shard details (allocation and topology, not lag)
                 for shard in status['shard_details']:
-                    if shard.get('behind_latest'):
-                        lag = shard.get('records_behind', 'unknown')
-                        logger.warning(f"Shard {shard['shard_id']} is behind by {lag} records")
+                    if shard['is_closed']:
+                        logger.info(f"Shard {shard['shard_id']} is closed")
+                    elif not shard['is_allocated']:
+                        logger.debug(f"Shard {shard['shard_id']} not allocated to this consumer")
 
                 # Performance metrics
                 elapsed = time.time() - self.metrics["start_time"]
@@ -653,6 +683,5 @@ async def run_monitoring():
 
 ## Next Steps
 
-- Review the [Performance Tuning Guide](./performance-tuning.md) for optimization tips
 - See [Troubleshooting Guide](./troubleshooting.md) for common issues
 - Check [Architecture Details](./DESIGN.md) for deep technical understanding

--- a/docs/dynamodb-checkpointing.md
+++ b/docs/dynamodb-checkpointing.md
@@ -49,24 +49,30 @@ async with Consumer(
 
 ### Multiple Consumer Groups
 
+Each consumer group needs its **own** DynamoDB table. The table key is `shard_id`
+only (see `kinesis/dynamodb.py`); there is no `name`/group namespace in the
+primary key, so two groups pointed at the same table would contend for the
+same rows and corrupt each other's leases and checkpoints.
+
 ```python
-# Analytics consumer group
+# Analytics consumer group: gets its own table (kinesis-checkpoints-analytics)
 analytics_consumer = Consumer(
     stream_name="events",
-    checkpointer=DynamoDBCheckPointer(
-        name="analytics",
-        table_name="kinesis-checkpoints"  # Share table across groups
-    )
+    checkpointer=DynamoDBCheckPointer(name="analytics"),
 )
 
-# Archival consumer group
+# Archival consumer group: separate table (kinesis-checkpoints-archival)
 archival_consumer = Consumer(
     stream_name="events",
-    checkpointer=DynamoDBCheckPointer(
-        name="archival",
-        table_name="kinesis-checkpoints"  # Same table, different app name
-    )
+    checkpointer=DynamoDBCheckPointer(name="archival"),
 )
+```
+
+If you need a custom table name per group, set `table_name` distinctly:
+
+```python
+DynamoDBCheckPointer(name="analytics", table_name="checkpoints-analytics-prod")
+DynamoDBCheckPointer(name="archival",  table_name="checkpoints-archival-prod")
 ```
 
 ## Configuration Options
@@ -244,7 +250,10 @@ For a stream with 10 shards and 5 consumers:
            batch = []
    ```
 
-3. **Share tables** across related applications to reduce operational overhead
+3. **Use one table per consumer group**. Sharing a table across groups is unsafe:
+   the primary key is `shard_id` only, so groups would overwrite each other's
+   leases. Reduce overhead by sharing other infrastructure (IAM, monitoring),
+   not the checkpoint table itself.
 
 ## Migration from Redis
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -15,7 +15,7 @@ This guide will walk you through setting up and using async-kinesis for the firs
 ## Prerequisites
 
 Before you begin, you should have:
-- Python 3.9 or higher installed
+- Python 3.10 or higher installed (matches `setup.py` `python_requires`)
 - Basic understanding of Python's async/await
 - An AWS account (free tier is sufficient for testing)
 - AWS credentials configured (we'll show you how)
@@ -119,22 +119,42 @@ if __name__ == "__main__":
 
 ## Complete Working Example
 
-Here's a complete example that demonstrates producer and consumer working together:
+Here's a complete example that demonstrates producer and consumer working together.
+
+Two ordering rules that the example below makes explicit:
+
+1. **Create the stream before the consumer starts.** If the consumer reaches
+   `async with Consumer(...)` before the stream exists, it raises. The producer's
+   `create_stream=True` only takes effect on enter, so launching both with
+   `asyncio.gather` is racy.
+2. **With `iterator_type="LATEST"`, wait for the consumer to be ready before
+   producing.** `LATEST` reads from records arriving *after* the iterator is
+   obtained. If the producer publishes first, those events are silently missed.
+   `Consumer.wait_ready()` blocks until shard iterators are in place.
 
 ```python
 import asyncio
-import json
 from datetime import datetime
 from kinesis import Producer, Consumer
 
-async def produce_events():
-    """Simulate producing user events"""
-    async with Producer(
-        stream_name="user-events",
-        create_stream=True,
-        create_stream_shards=2  # Use 2 shards for parallel processing
-    ) as producer:
+STREAM_NAME = "user-events"
 
+
+async def setup_stream():
+    """Pre-create the stream so the consumer doesn't race against creation."""
+    async with Producer(
+        stream_name=STREAM_NAME,
+        create_stream=True,
+        create_stream_shards=2,  # 2 shards for parallel processing
+    ):
+        pass  # entering the context creates the stream; exit is a no-op here
+
+
+async def produce_events(ready: asyncio.Event):
+    """Wait until the consumer is ready, then publish."""
+    await ready.wait()
+
+    async with Producer(stream_name=STREAM_NAME) as producer:
         users = ["alice", "bob", "charlie", "diana"]
         actions = ["login", "purchase", "view_item", "logout"]
 
@@ -144,50 +164,44 @@ async def produce_events():
                 "user_id": user,
                 "action": actions[i % len(actions)],
                 "timestamp": datetime.now().isoformat(),
-                "value": i * 10
+                "value": i * 10,
             }
-
-            # Use user_id as partition key to ensure all events
-            # for a user go to the same shard (maintaining order)
+            # Use user_id as partition key so all of a user's events
+            # land on the same shard (maintaining order).
             await producer.put(event, partition_key=user)
             print(f"Sent event: {event['user_id']} - {event['action']}")
-
-            # Small delay to simulate real-time events
             await asyncio.sleep(0.5)
 
-async def process_events():
-    """Process user events as they arrive"""
-    async with Consumer(
-        stream_name="user-events",
-        iterator_type="LATEST"  # Start from new messages only
-    ) as consumer:
 
-        print("Consumer started, waiting for events...")
+async def process_events(ready: asyncio.Event):
+    """Start the consumer and signal readiness once shard iterators are in place."""
+    async with Consumer(
+        stream_name=STREAM_NAME,
+        iterator_type="LATEST",  # Only events arriving after we're ready
+    ) as consumer:
+        await consumer.wait_ready()  # safe to produce after this
+        ready.set()
+        print("Consumer ready, waiting for events...")
 
         async for event in consumer:
-            # Process the event
             user = event["user_id"]
             action = event["action"]
             value = event.get("value", 0)
-
             print(f"Processing: {user} performed {action} (value: ${value})")
 
-            # Simulate some processing work
             if action == "purchase":
-                print(f"  💰 Recording purchase of ${value} for {user}")
+                print(f"  Recording purchase of ${value} for {user}")
             elif action == "login":
-                print(f"  👤 User {user} logged in")
+                print(f"  User {user} logged in")
+
 
 async def main():
-    """Run producer and consumer concurrently"""
-    # Start both producer and consumer at the same time
-    await asyncio.gather(
-        produce_events(),
-        process_events()
-    )
+    await setup_stream()  # create stream first
+    ready = asyncio.Event()
+    await asyncio.gather(produce_events(ready), process_events(ready))
+
 
 if __name__ == "__main__":
-    # Run for 30 seconds then stop
     try:
         asyncio.run(asyncio.wait_for(main(), timeout=30))
     except asyncio.TimeoutError:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -277,8 +277,10 @@ async def parallel_puts(producer, records):
 
 4. **Monitor queue size:**
 ```python
-# Check if queue is full (blocking puts)
-if producer._queue.qsize() > producer._max_queue_size * 0.8:
+# Check if the in-memory put queue is filling up (blocking puts).
+# `producer.queue` is the asyncio.Queue created from `max_queue_size`,
+# so use `.maxsize` (asyncio.Queue's standard attribute) for the threshold.
+if producer.queue.qsize() > producer.queue.maxsize * 0.8:
     print("Warning: Queue nearly full, consider increasing max_queue_size")
 ```
 
@@ -322,11 +324,12 @@ async with Consumer(stream_name="test") as consumer:
         print(f"Parent {parent} has children: {children}")
 ```
 
-2. **Force shard refresh:**
+2. **Trigger shard refresh:**
 ```python
-# Manually trigger shard discovery (usually not needed)
-consumer._resharding_manager._last_refresh = 0
-await consumer._resharding_manager.refresh_shards()
+# The consumer auto-refreshes shards on a 60s interval. Calling refresh_shards()
+# directly is a no-op if the throttle window has not yet elapsed (the interval
+# is currently a private constant; there is no public API to bypass it).
+await consumer.refresh_shards()
 ```
 
 3. **Monitor resharding events:**
@@ -456,7 +459,7 @@ logging.getLogger('botocore').setLevel(logging.INFO)
 # Producer metrics
 async def monitor_producer(producer):
     while True:
-        queue_size = producer._queue.qsize()
+        queue_size = producer.queue.qsize()
         print(f"Producer queue size: {queue_size}")
         await asyncio.sleep(10)
 


### PR DESCRIPTION
## Summary

Audit pass across `docs/` against the current implementation in `kinesis/`. Nine docs claims were stale or wrong; this PR brings the guides back in line with the code without changing any behavior.

## Changes

- **dynamodb-checkpointing.md**, drop the "share one table across consumer groups" example. Primary key is `shard_id` only, so two groups would overwrite each other's leases. Updated best-practices accordingly.
- **common-patterns.md (IoT)**, switch the example from `KPLJsonProcessor` to `JsonProcessor`. `KPLAggregator.add_item()` raises `ValueError` if a custom `partition_key` is passed, so the previous example crashed on first `put()`.
- **common-patterns.md (event streaming)**, add an install note for `MsgpackProcessor` (`pip install async-kinesis[msgpack]`). The serializer swallows the missing import, so the failure surfaces later as `NameError` on first `put()` / iteration, not `ImportError` at import.
- **common-patterns.md (monitoring)**, rewrite to use only real `get_shard_status()` fields (`allocated_shards`, `parent_shards`, `child_shards`, `expired_parents`, `resharding_in_progress`). The previous version referenced `behind_shards` / `behind_latest` / `records_behind` which the API does not produce. Lag now points at the `CONSUMER_ITERATOR_AGE` metric and CloudWatch's `GetRecords.IteratorAgeMilliseconds`.
- **common-patterns.md**, remove dead link to `./performance-tuning.md` (file doesn't exist).
- **getting-started.md (complete example)**, pre-create the stream before launching producer + consumer concurrently, and call `consumer.wait_ready()` before publishing. Fixes the `iterator_type="LATEST"` race that could silently miss early events.
- **getting-started.md**, bump prerequisite from Python 3.9 to 3.10 (matches `setup.py` `python_requires`).
- **troubleshooting.md**, `producer._queue` / `producer._max_queue_size` -> public `producer.queue.qsize()` / `.maxsize`.
- **troubleshooting.md**, replace nonexistent `consumer._resharding_manager.refresh_shards()` with `consumer.refresh_shards()`. Honestly document the 60s throttle (no public bypass).

## Backwards compatibility

Docs-only. No code, no API changes.

## Test plan

- [x] `git diff --stat` confirms only `docs/` changes (4 files, +119 -64)
- [x] All claims verified against current `kinesis/` code (Codex + Gemini focused review)
- [ ] CI markdownlint passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated minimum Python requirement to 3.10+
  * Enhanced processor configuration guidance with clearer examples for streaming and data collection
  * Clarified DynamoDB checkpoint table setup requirements (one table per consumer group)
  * Improved getting-started example with explicit ordering guarantees for stream creation and consumer readiness
  * Refined troubleshooting examples for queue monitoring and resharding detection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->