### PR TITLE
fix(consumer): skip get_records when client is mid-reconnect (#73)

### DIFF
--- a/kinesis/consumer.py
+++ b/kinesis/consumer.py
@@ -489,9 +489,23 @@ class Consumer(Base):
         async with shard["throttler"]:
             # log.debug("get_records shard={}".format(shard['ShardId']))
 
+            # Snapshot the client. _get_reconn_helper() (base.py) sets
+            # self.client = None while rebuilding the aiobotocore client, and
+            # the throttler's async-with above is an await point: self.client
+            # can flip to None during it. Read once so the check and the call
+            # below are atomic with respect to the shared attribute. Without
+            # this, concurrent shards land in the catch-all with
+            # AttributeError("'NoneType' object has no attribute 'get_records'")
+            # and pollute error_type=unknown; the triggering connection error
+            # was already counted on the shard that initiated the reconnect.
+            client = self.client
+            if client is None:
+                log.debug("client rebuild in progress, skipping get_records on %s", shard["ShardId"])
+                return None
+
             try:
 
-                result = await self.client.get_records(ShardIterator=shard["ShardIterator"], Limit=self.record_limit)
+                result = await client.get_records(ShardIterator=shard["ShardIterator"], Limit=self.record_limit)
 
                 shard["stats"].succeded()
                 return result

--- a/tests/test_metrics_unit.py
+++ b/tests/test_metrics_unit.py
@@ -636,6 +636,61 @@ class TestConsumerGetRecordsErrors:
         key = f"consumer_errors_total{{error_type=unknown,{_shard_labels('shard-0')}}}"
         assert collector.counters[key] == 1
 
+    @pytest.mark.asyncio
+    async def test_none_client_skips_without_raising_or_counting_error(self, mock_consumer):
+        """When _get_reconn_helper has set self.client = None on one shard's
+        connection error, concurrent get_records dispatches from fetch() must
+        return None quietly rather than hit the catch-all with
+        AttributeError("'NoneType' object has no attribute 'get_records'") and
+        pollute error_type=unknown. Regression from 2.5.2 reported on #73."""
+        collector = InMemoryMetricsCollector()
+        consumer = mock_consumer(metrics_collector=collector)
+        consumer.client = None  # simulate mid-reconnect state
+
+        result = await consumer.get_records(self._shard())
+
+        assert result is None
+        # No error metric should be emitted for the skipped-because-rebuilding
+        # case; the triggering connection error was already counted on the
+        # shard that initiated the reconnect.
+        assert not any(k.startswith("consumer_errors_total") for k in collector.counters), collector.counters
+
+    @pytest.mark.asyncio
+    async def test_client_nulled_during_throttler_await_does_not_raise(self, mock_consumer):
+        """Tighter race: self.client is valid on function entry but flips to
+        None while the throttler's __aenter__ is awaiting (e.g. another shard
+        triggered _get_reconn_helper in the meantime). The snapshot-and-check
+        inside the throttler block must catch this; without it, dereferencing
+        self.client later in the same method would AttributeError and pollute
+        error_type=unknown."""
+        collector = InMemoryMetricsCollector()
+        consumer = mock_consumer(metrics_collector=collector)
+        consumer.client = MagicMock()
+        consumer.client.get_records = AsyncMock(return_value={"Records": [], "NextShardIterator": "next"})
+
+        shard = self._shard()
+
+        # Wrap the throttler so that during its acquire (an await point),
+        # consumer.client flips to None. Simulates _get_reconn_helper running
+        # on another task between function entry and the get_records call.
+        real_throttler = shard["throttler"]
+
+        class RaceThrottler:
+            async def __aenter__(self):
+                await real_throttler.__aenter__()
+                consumer.client = None
+                return self
+
+            async def __aexit__(self, *exc):
+                return await real_throttler.__aexit__(*exc)
+
+        shard["throttler"] = RaceThrottler()
+
+        result = await consumer.get_records(shard)
+
+        assert result is None
+        assert not any(k.startswith("consumer_errors_total") for k in collector.counters), collector.counters
+
 
 async def _make_redis_cp(auto_checkpoint=True):
     """Construct a RedisCheckPointer with a mocked client and a cancelled heartbeat task.


### PR DESCRIPTION
## Summary

Regression reported by @akursar on 2.5.2: logs flooded with `Unknown error 'NoneType' object has no attribute 'get_records'. sleeping..` when running against real AWS Kinesis with 18 shards.

Root cause is a pre-existing race **exposed** (not introduced) by #90.

1. Shard A hits `ConnectionClosedError` at `consumer.py:499`, which now correctly calls `self.get_conn()`.
2. If the 120s backoff elapsed, `_get_reconn_helper()` (`base.py:261`) runs and sets `self.client = None` for 5+ seconds while rebuilding the aiobotocore client.
3. Meanwhile `_fetch()` loops every 0.2s, dispatching fresh `get_records` tasks for the other 17 shards.
4. Those tasks hit `await self.client.get_records(...)` with `self.client = None`, raise `AttributeError`, land in the catch-all at `consumer.py:567`, and are mislabeled `error_type="unknown"`.

Before #90, `ConnectionClosedError` fell through to the catch-all and never triggered reconnect, so the race never opened. #90 correctly routes it through `get_conn()`, which surfaces the pre-existing race.

## Fix

Snapshot `self.client` into a local variable **inside** the throttler block (the throttler's `__aenter__` is an `await` point, so `self.client` can flip to `None` during it). If the snapshot is `None`, the client is being rebuilt: return `None` quietly rather than raise. The triggering connection error was already counted on the shard that initiated the reconnect, so no double count. `fetch()` already handles a `None` result (emits queue gauge, re-emits cached iterator age, re-dispatches next iteration).

## Backwards compatibility

- **No public API changes.**
- **Error-metric shift**: events previously landing in `error_type="unknown"` via this specific race no longer emit at all. They were never real errors, just shards racing a reconnect. Total `consumer_errors_total` rate drops slightly.

## Test plan

- [x] `test_none_client_skips_without_raising_or_counting_error` (client `None` on entry)
- [x] `test_client_nulled_during_throttler_await_does_not_raise` (client flips to `None` during `throttler.__aenter__`, the actual TOCTOU Codex flagged on the first review pass)
- [x] Full non-Docker suite: 168 passed, 7 skipped
- [x] black / isort / flake8 clean
- [x] Codex + Gemini focused review (clean on revised diff; Codex caught the TOCTOU on the first pass, fixed with local-snapshot + tighter test)
- [ ] Integration smoke test with Floci (CI)

Refs: #73

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a race condition that could cause errors during concurrent shard processing when the client rebuilds or reconnects.

* **Tests**
  * Added unit tests to verify proper handling of concurrent execution and client reconnection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->