### PR TITLE
fix(checkpointer): close #81 papercuts in BaseHeartbeatCheckPointer

### DIFF
--- a/kinesis/__init__.py
+++ b/kinesis/__init__.py
@@ -1,5 +1,5 @@
 from .aggregators import ListAggregator, NetstringAggregator, NewlineAggregator, SimpleAggregator
-from .checkpointers import CheckpointFlushError, MemoryCheckPointer, RedisCheckPointer
+from .checkpointers import CheckpointFlushError, CheckpointOwnershipConflict, MemoryCheckPointer, RedisCheckPointer
 from .consumer import Consumer
 from .metrics import (
     InMemoryMetricsCollector,

--- a/kinesis/checkpointers.py
+++ b/kinesis/checkpointers.py
@@ -31,6 +31,10 @@ class CheckpointFlushError(Exception):
         super().__init__(f"{len(errors)} shard(s) failed to checkpoint: {shard_ids}")
 
 
+class CheckpointOwnershipConflict(Exception):
+    """Raised when a Redis checkpoint write detects the lease was lost (key evicted or ref mismatch)."""
+
+
 class CheckPointer(Protocol):
     """Protocol for checkpointer implementations.
 
@@ -188,6 +192,13 @@ class BaseHeartbeatCheckPointer(BaseCheckPointer):
     async def close(self):
         log.debug("Cancelling heartbeat task..")
         self.heartbeat_task.cancel()
+        try:
+            await self.heartbeat_task
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            # Swallow so super().close() still runs and deallocates shards.
+            log.warning("heartbeat task exited with error on close", exc_info=True)
 
         await super().close()
 
@@ -196,7 +207,8 @@ class BaseHeartbeatCheckPointer(BaseCheckPointer):
             await asyncio.sleep(self.heartbeat_frequency)
 
             # todo: don't heartbeat if checkpoint already updated it recently
-            for shard_id, sequence in self._items.items():
+            # Snapshot: deallocate() may mutate _items while do_heartbeat() awaits.
+            for shard_id, sequence in list(self._items.items()):
                 key = self.get_key(shard_id)
                 val = {"ref": self.get_ref(), "ts": self.get_ts(), "sequence": sequence}
                 log.debug("Heartbeating {}@{}".format(shard_id, sequence))
@@ -340,13 +352,15 @@ class RedisCheckPointer(BaseHeartbeatCheckPointer):
             previous_val = json.loads(previous_val) if previous_val else None
 
             if not previous_val:
-                raise NotImplementedError(
+                raise CheckpointOwnershipConflict(
                     "{} checkpointed on {} but key did not exist?".format(self.get_ref(), shard_id)
                 )
 
             if previous_val["ref"] != self.get_ref():
-                raise NotImplementedError(
-                    "{} checkpointed on {} but ref is different {}".format(self.get_ref(), shard_id, val["ref"])
+                raise CheckpointOwnershipConflict(
+                    "{} checkpointed on {} but ref is different {}".format(
+                        self.get_ref(), shard_id, previous_val["ref"]
+                    )
                 )
 
             log.debug("{} checkpointed on {}@{}".format(self.get_ref(), shard_id, sequence))

--- a/tests/test_checkpoint_base_contract.py
+++ b/tests/test_checkpoint_base_contract.py
@@ -217,7 +217,7 @@ class TestHeartbeatRobustness:
             seen.append(key)
             # Mid-tick: simulate concurrent deallocate() popping another shard.
             cp._items.pop("shard-1", None)
-            if len(seen) == 2:
+            if {"shard-0", "shard-1"}.issubset(seen):
                 both_seen.set()
 
         cp.do_heartbeat = mutating_heartbeat
@@ -234,7 +234,10 @@ class TestHeartbeatRobustness:
             except asyncio.CancelledError:
                 pass
 
-        assert len(seen) == 2, f"iteration aborted early (missing fix?): {seen}"
+        # Extra shard-0 observations from subsequent ticks before cancel are
+        # fine; we only care that the first tick processed both snapshot
+        # entries instead of raising RuntimeError mid-iteration.
+        assert {"shard-0", "shard-1"}.issubset(seen), f"iteration aborted early (missing fix?): {seen}"
 
     @pytest.mark.asyncio
     async def test_close_deallocates_when_heartbeat_crashed(self):

--- a/tests/test_checkpoint_base_contract.py
+++ b/tests/test_checkpoint_base_contract.py
@@ -184,3 +184,84 @@ class TestBaseCheckpointContract:
 
         assert cp._manual_checkpoints == {"shard-0": "seq-2"}
         assert cp.writes == {"shard-0": "seq-1"}
+
+
+class TestHeartbeatRobustness:
+    """Issue #81: heartbeat iteration and close() must survive concurrent
+    mutation / task death so shards don't leak."""
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_survives_concurrent_items_mutation(self):
+        """Without list(self._items.items()), a concurrent deallocate()-style
+        pop during the awaited do_heartbeat raises
+        RuntimeError: dictionary changed size during iteration.
+
+        Doesn't claim to stop stale writes on de-allocated shards: that's a
+        separate ownership-race problem (see PLAN_ISSUE_80). Only guards the
+        iteration itself.
+        """
+        cp = FakeHeartbeatCheckPointer()
+        # Drain the auto-started heartbeat task; we drive our own below.
+        cp.heartbeat_task.cancel()
+        try:
+            await cp.heartbeat_task
+        except asyncio.CancelledError:
+            pass
+
+        cp._items = {"shard-0": "seq-0", "shard-1": "seq-1"}
+        cp.heartbeat_frequency = 0
+        both_seen = asyncio.Event()
+        seen = []
+
+        async def mutating_heartbeat(key, value):
+            seen.append(key)
+            # Mid-tick: simulate concurrent deallocate() popping another shard.
+            cp._items.pop("shard-1", None)
+            if len(seen) == 2:
+                both_seen.set()
+
+        cp.do_heartbeat = mutating_heartbeat
+
+        task = asyncio.create_task(cp.heartbeat())
+        try:
+            # Without the list() snapshot, the iterator raises after the first
+            # tick body pops shard-1 and both_seen never fires.
+            await asyncio.wait_for(both_seen.wait(), timeout=1.0)
+        finally:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        assert len(seen) == 2, f"iteration aborted early (missing fix?): {seen}"
+
+    @pytest.mark.asyncio
+    async def test_close_deallocates_when_heartbeat_crashed(self):
+        """If the heartbeat task died with a non-Cancel exception before
+        close() was called, close() must still deallocate every shard.
+        Guards against the PR #83 shape that awaited the task but only
+        swallowed CancelledError.
+        """
+
+        class CrashingHeartbeatCheckPointer(FakeHeartbeatCheckPointer):
+            async def heartbeat(self):
+                raise RuntimeError("heartbeat dead")
+
+        cp = CrashingHeartbeatCheckPointer()
+        await cp.allocate("shard-0")
+        await cp.allocate("shard-1")
+        assert cp._items == {"shard-0": None, "shard-1": None}
+
+        # Let the task run and die.
+        for _ in range(20):
+            await asyncio.sleep(0)
+            if cp.heartbeat_task.done():
+                break
+        assert cp.heartbeat_task.done()
+
+        # Without the broad `except Exception` in close(), awaiting the crashed
+        # task re-raises RuntimeError and super().close() never runs.
+        await cp.close()
+
+        assert cp._items == {}

--- a/tests/test_metrics_unit.py
+++ b/tests/test_metrics_unit.py
@@ -15,6 +15,7 @@ from botocore.exceptions import (
 
 from kinesis import (
     CheckpointFlushError,
+    CheckpointOwnershipConflict,
     InMemoryMetricsCollector,
     MemoryCheckPointer,
     MetricType,
@@ -783,7 +784,7 @@ class TestConsumerCheckpointMetrics:
         collector = InMemoryMetricsCollector()
         cp = await _make_redis_cp(auto_checkpoint=False)
         cp.bind_metrics(collector, {"stream_name": "test-stream"})
-        cp.client.getset = AsyncMock(return_value=None)  # triggers NotImplementedError
+        cp.client.getset = AsyncMock(return_value=None)  # triggers CheckpointOwnershipConflict
 
         try:
             await cp.checkpoint("shard-0", "seq-1")
@@ -795,7 +796,7 @@ class TestConsumerCheckpointMetrics:
 
             # Best-effort flush: every shard was attempted, every shard raised.
             assert [shard_id for shard_id, _ in exc_info.value.errors] == ["shard-0", "shard-1"]
-            assert all(isinstance(exc, NotImplementedError) for _, exc in exc_info.value.errors)
+            assert all(isinstance(exc, CheckpointOwnershipConflict) for _, exc in exc_info.value.errors)
 
             # Both failed, so both remain buffered.
             assert cp._manual_checkpoints == {"shard-0": "seq-1", "shard-1": "seq-9"}
@@ -872,7 +873,7 @@ class TestConsumerCheckpointMetrics:
         """CheckpointFlushError lists every failing shard in its message, and
         ``__cause__`` points at the first underlying exception for traceback."""
         cp = await _make_redis_cp(auto_checkpoint=False)
-        cp.client.getset = AsyncMock(return_value=None)  # triggers NotImplementedError
+        cp.client.getset = AsyncMock(return_value=None)  # triggers CheckpointOwnershipConflict
 
         try:
             await cp.checkpoint("shard-0", "seq-1")
@@ -888,7 +889,29 @@ class TestConsumerCheckpointMetrics:
         assert "shard-0" in str(exc) and "shard-1" in str(exc)
         # __cause__ is the first collected exception (insertion order).
         assert exc.__cause__ is exc.errors[0][1]
-        assert isinstance(exc.__cause__, NotImplementedError)
+        assert isinstance(exc.__cause__, CheckpointOwnershipConflict)
+
+    @pytest.mark.asyncio
+    async def test_checkpoint_ref_mismatch_raises_with_conflicting_owner(self):
+        """Issue #81: ref-mismatch branch of _checkpoint must raise
+        CheckpointOwnershipConflict and name the *conflicting* owner (the ref
+        that currently holds the lease), not this consumer's own ref. The
+        original code printed val["ref"] (self), which was useless for
+        diagnosing who stole the lease.
+        """
+        cp = await _make_redis_cp()
+        other_owner = "other-consumer/12345"
+        previous_val = '{"ref": "' + other_owner + '", "ts": 0, "sequence": "seq-prev"}'
+        cp.client.getset = AsyncMock(return_value=previous_val)
+
+        try:
+            with pytest.raises(CheckpointOwnershipConflict) as exc_info:
+                await cp._checkpoint("shard-0", "seq-1")
+        finally:
+            await cp.close()
+
+        msg = str(exc_info.value)
+        assert other_owner in msg, f"expected conflicting owner in message: {msg!r}"
 
     @pytest.mark.asyncio
     async def test_manual_checkpoint_no_raise_on_all_success(self):


### PR DESCRIPTION
## Summary

Three related papercuts in `BaseHeartbeatCheckPointer` (and the `RedisCheckPointer` subclass) from #81:

- **Typed ownership-conflict exception**. `RedisCheckPointer._checkpoint()` raised `NotImplementedError` for two different lease-loss conditions (key evicted, ref mismatch), which was both mis-labelled and unhelpful for callers. It now raises a new public `CheckpointOwnershipConflict` in both branches. The ref-mismatch message also now prints the conflicting owner (`previous_val["ref"]`) instead of this consumer's own ref, so the log line actually names who holds the lease.
- **Heartbeat iteration survives concurrent mutation**. `heartbeat()` iterates `list(self._items.items())`. Without the snapshot, a concurrent `deallocate()` during the awaited `do_heartbeat()` raised `RuntimeError: dictionary changed size during iteration`, taking the heartbeat task down. Scope: guards the iteration only; it does not prevent a stale heartbeat write landing on a shard that was de-allocated during the await. That stale-write class of bug overlaps with the ownership races tracked separately (#80 hazard 3, and the GETSET race in the issue).
- **`close()` always deallocates shards**. `close()` now awaits the heartbeat task and swallows both `CancelledError` and other exceptions, so `super().close()` always runs. Previously, if the heartbeat had died on a non-Cancel error before `close()`, awaiting it would bubble the exception and skip shard deallocation (shard leak on shutdown). The swallow logs at `warning` with `exc_info=True` so the traceback survives.

## Tests

- `test_heartbeat_survives_concurrent_items_mutation`, drives one heartbeat tick where `do_heartbeat` pops a sibling shard; asserts no `RuntimeError` and that every snapshot entry is still processed. Fails without the `list()` fix.
- `test_close_deallocates_when_heartbeat_crashed`, subclass whose `heartbeat()` raises `RuntimeError`; after `close()`, `_items` is empty. Fails without the broad `except Exception` in `close()`.
- `test_checkpoint_ref_mismatch_raises_with_conflicting_owner`, `getset` returns a different `ref`; asserts the conflicting owner's ref appears in the exception message. Fails against the original `val["ref"]` formatting.
- Existing `test_metrics_unit.py` sites updated to expect `CheckpointOwnershipConflict` instead of `NotImplementedError`.

## Backwards compatibility

**Breaking**: `RedisCheckPointer._checkpoint()` (and therefore `checkpoint()` / `manual_checkpoint()`) now raises `CheckpointOwnershipConflict` instead of `NotImplementedError` on ownership loss. Callers that were catching `NotImplementedError` on checkpoint calls need to switch to `CheckpointOwnershipConflict`. Greppable across the Connect/NUI consumers: no catches found. Not making it subclass `NotImplementedError` for a compat window, the original exception type was wrong, and a compat shim would keep the mistake alive.

`DynamoDBCheckPointer` still raises a bare `Exception` on ownership loss. Consciously inconsistent with the Redis path for this PR; Dynamo has its own condition-expression logic and test suite. Follow-up issue to align the two backends.

## Test plan

- [x] 3 new regression tests (two in base-class contract file, one for the ref-mismatch message)
- [x] Updated 4 existing NotImplementedError assertions + import
- [x] Full non-integration suite green (196 passed, 8 skipped)
- [x] black + isort + flake8 clean
- [x] External review by Codex and Gemini; two actionable findings applied (extra ref-mismatch test, `exc_info=True` on warning log)
- [ ] Docker/integration suite (not run locally; CI will cover)

## Credits

Replaces #83 (stalled). Original spike by @itniuma2026, redone from `master` rather than rebased over #79 + #86 to avoid regressions in those merges.

Closes #81.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `CheckpointOwnershipConflict` exception for more specific checkpoint ownership conflict detection.

* **Bug Fixes**
  * Improved heartbeat robustness during concurrent checkpointer operations.
  * Enhanced shutdown handling to ensure graceful termination in all scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->