### PR TITLE
fix(consumer): stop rebuilding client on transient get_records errors (#73)

### DIFF
--- a/kinesis/consumer.py
+++ b/kinesis/consumer.py
@@ -518,8 +518,8 @@ class Consumer(Base):
                     1,
                     {"stream_name": self.stream_name, "shard_id": shard["ShardId"], "error_type": "connection"},
                 )
-                log.warning("Connection error {}. rebuilding client..".format(e))
-                await self.get_conn()
+                log.warning("Connection error {}. sleeping..".format(e))
+                await asyncio.sleep(3)
             except (TimeoutError, ReadTimeoutError) as e:
                 self.metrics.increment(
                     MetricType.CONSUMER_ERRORS,
@@ -571,8 +571,8 @@ class Consumer(Base):
                         shard.pop("ShardIterator", None)
 
                 elif code == "InternalFailure":
-                    log.warning("Received InternalFailure from Kinesis, rebuilding connection.. ")
-                    await self.get_conn()
+                    log.warning("Received InternalFailure from Kinesis, sleeping..")
+                    await asyncio.sleep(3)
 
                 else:
                     log.warning("ClientError {}. sleeping..".format(code))

--- a/kinesis/consumer.py
+++ b/kinesis/consumer.py
@@ -571,7 +571,8 @@ class Consumer(Base):
                         shard.pop("ShardIterator", None)
 
                 elif code == "InternalFailure":
-                    log.warning("Received InternalFailure from Kinesis, sleeping..")
+                    message = e.response.get("Error", {}).get("Message", str(e))
+                    log.warning("Received InternalFailure from Kinesis: {}. sleeping..".format(message))
                     await asyncio.sleep(3)
 
                 else:

--- a/tests/test_metrics_unit.py
+++ b/tests/test_metrics_unit.py
@@ -28,6 +28,18 @@ from kinesis.metrics import Timer
 from kinesis.utils import Throttler
 
 
+@pytest.fixture
+def fast_asyncio_sleep(monkeypatch):
+    """Replace asyncio.sleep with a zero-delay awaitable for retry-path tests."""
+    orig_sleep = asyncio.sleep
+
+    async def fast_sleep(_):
+        await orig_sleep(0)
+
+    monkeypatch.setattr(asyncio, "sleep", fast_sleep)
+    return fast_sleep
+
+
 class TestNoOpMetricsCollector:
     def test_all_operations_are_noop(self):
         """Test that NoOpMetricsCollector does nothing."""
@@ -501,28 +513,21 @@ class TestConsumerGetRecordsErrors:
         }
 
     @pytest.mark.asyncio
-    async def test_connection_error_emits_connection_label(self, mock_consumer):
+    async def test_connection_error_emits_connection_label(self, mock_consumer, fast_asyncio_sleep):
         collector = InMemoryMetricsCollector()
         consumer = mock_consumer(metrics_collector=collector)
         consumer.client = MagicMock()
         consumer.client.get_records = AsyncMock(side_effect=ClientConnectionError("boom"))
         consumer.get_conn = AsyncMock()
 
-        orig_sleep = asyncio.sleep
-
-        async def fast_sleep(_):
-            await orig_sleep(0)
-
-        with pytest.MonkeyPatch().context() as mp:
-            mp.setattr(asyncio, "sleep", fast_sleep)
-            await consumer.get_records(self._shard())
+        await consumer.get_records(self._shard())
 
         key = f"consumer_errors_total{{error_type=connection,{_shard_labels('shard-0')}}}"
         assert collector.counters[key] == 1
         consumer.get_conn.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_botocore_connection_closed_emits_connection_label(self, mock_consumer):
+    async def test_botocore_connection_closed_emits_connection_label(self, mock_consumer, fast_asyncio_sleep):
         """Real AWS commonly raises botocore ConnectionClosedError when an idle
         keep-alive connection is dropped mid-response. Prior to #73 fix this fell
         through to the catch-all and got mislabeled as error_type=unknown."""
@@ -534,21 +539,14 @@ class TestConsumerGetRecordsErrors:
         )
         consumer.get_conn = AsyncMock()
 
-        orig_sleep = asyncio.sleep
-
-        async def fast_sleep(_):
-            await orig_sleep(0)
-
-        with pytest.MonkeyPatch().context() as mp:
-            mp.setattr(asyncio, "sleep", fast_sleep)
-            await consumer.get_records(self._shard())
+        await consumer.get_records(self._shard())
 
         key = f"consumer_errors_total{{error_type=connection,{_shard_labels('shard-0')}}}"
         assert collector.counters[key] == 1
         consumer.get_conn.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_botocore_endpoint_connection_error_emits_connection_label(self, mock_consumer):
+    async def test_botocore_endpoint_connection_error_emits_connection_label(self, mock_consumer, fast_asyncio_sleep):
         """botocore.EndpointConnectionError (DNS/TCP failure before request is sent)
         should be counted as a connection error and return without rebuilding."""
         collector = InMemoryMetricsCollector()
@@ -559,21 +557,14 @@ class TestConsumerGetRecordsErrors:
         )
         consumer.get_conn = AsyncMock()
 
-        orig_sleep = asyncio.sleep
-
-        async def fast_sleep(_):
-            await orig_sleep(0)
-
-        with pytest.MonkeyPatch().context() as mp:
-            mp.setattr(asyncio, "sleep", fast_sleep)
-            await consumer.get_records(self._shard())
+        await consumer.get_records(self._shard())
 
         key = f"consumer_errors_total{{error_type=connection,{_shard_labels('shard-0')}}}"
         assert collector.counters[key] == 1
         consumer.get_conn.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_botocore_read_timeout_emits_timeout_label(self, mock_consumer):
+    async def test_botocore_read_timeout_emits_timeout_label(self, mock_consumer, fast_asyncio_sleep):
         """botocore.ReadTimeoutError lands in the timeout bucket, not unknown."""
         collector = InMemoryMetricsCollector()
         consumer = mock_consumer(metrics_collector=collector)
@@ -582,40 +573,25 @@ class TestConsumerGetRecordsErrors:
             side_effect=ReadTimeoutError(endpoint_url="https://kinesis.us-east-1.amazonaws.com/")
         )
 
-        orig_sleep = asyncio.sleep
-
-        async def fast_sleep(_):
-            await orig_sleep(0)
-
-        with pytest.MonkeyPatch().context() as mp:
-            mp.setattr(asyncio, "sleep", fast_sleep)
-            await consumer.get_records(self._shard())
+        await consumer.get_records(self._shard())
 
         key = f"consumer_errors_total{{error_type=timeout,{_shard_labels('shard-0')}}}"
         assert collector.counters[key] == 1
 
     @pytest.mark.asyncio
-    async def test_timeout_emits_timeout_label(self, mock_consumer):
+    async def test_timeout_emits_timeout_label(self, mock_consumer, fast_asyncio_sleep):
         collector = InMemoryMetricsCollector()
         consumer = mock_consumer(metrics_collector=collector)
         consumer.client = MagicMock()
         consumer.client.get_records = AsyncMock(side_effect=asyncio.TimeoutError())
 
-        # Monkeypatch asyncio.sleep inside the except block to avoid 3s wait.
-        orig_sleep = asyncio.sleep
-
-        async def fast_sleep(_):
-            await orig_sleep(0)
-
-        with pytest.MonkeyPatch().context() as mp:
-            mp.setattr(asyncio, "sleep", fast_sleep)
-            await consumer.get_records(self._shard())
+        await consumer.get_records(self._shard())
 
         key = f"consumer_errors_total{{error_type=timeout,{_shard_labels('shard-0')}}}"
         assert collector.counters[key] == 1
 
     @pytest.mark.asyncio
-    async def test_client_error_emits_raw_code_label(self, mock_consumer):
+    async def test_client_error_emits_raw_code_label(self, mock_consumer, fast_asyncio_sleep):
         collector = InMemoryMetricsCollector()
         consumer = mock_consumer(metrics_collector=collector)
         err = ClientError(
@@ -625,14 +601,7 @@ class TestConsumerGetRecordsErrors:
         consumer.client = MagicMock()
         consumer.client.get_records = AsyncMock(side_effect=err)
 
-        orig_sleep = asyncio.sleep
-
-        async def fast_sleep(_):
-            await orig_sleep(0)
-
-        with pytest.MonkeyPatch().context() as mp:
-            mp.setattr(asyncio, "sleep", fast_sleep)
-            await consumer.get_records(self._shard())
+        await consumer.get_records(self._shard())
 
         key = (
             "consumer_errors_total{" f"error_type=ProvisionedThroughputExceededException,{_shard_labels('shard-0')}" "}"
@@ -640,7 +609,7 @@ class TestConsumerGetRecordsErrors:
         assert collector.counters[key] == 1
 
     @pytest.mark.asyncio
-    async def test_internal_failure_no_longer_rebuilds(self, mock_consumer):
+    async def test_internal_failure_no_longer_rebuilds(self, mock_consumer, fast_asyncio_sleep):
         collector = InMemoryMetricsCollector()
         consumer = mock_consumer(metrics_collector=collector)
         err = ClientError(
@@ -651,34 +620,20 @@ class TestConsumerGetRecordsErrors:
         consumer.client.get_records = AsyncMock(side_effect=err)
         consumer.get_conn = AsyncMock()
 
-        orig_sleep = asyncio.sleep
-
-        async def fast_sleep(_):
-            await orig_sleep(0)
-
-        with pytest.MonkeyPatch().context() as mp:
-            mp.setattr(asyncio, "sleep", fast_sleep)
-            await consumer.get_records(self._shard())
+        await consumer.get_records(self._shard())
 
         key = f"consumer_errors_total{{error_type=InternalFailure,{_shard_labels('shard-0')}}}"
         assert collector.counters[key] == 1
         consumer.get_conn.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_unknown_exception_emits_unknown_label(self, mock_consumer):
+    async def test_unknown_exception_emits_unknown_label(self, mock_consumer, fast_asyncio_sleep):
         collector = InMemoryMetricsCollector()
         consumer = mock_consumer(metrics_collector=collector)
         consumer.client = MagicMock()
         consumer.client.get_records = AsyncMock(side_effect=RuntimeError("surprise"))
 
-        orig_sleep = asyncio.sleep
-
-        async def fast_sleep(_):
-            await orig_sleep(0)
-
-        with pytest.MonkeyPatch().context() as mp:
-            mp.setattr(asyncio, "sleep", fast_sleep)
-            await consumer.get_records(self._shard())
+        await consumer.get_records(self._shard())
 
         key = f"consumer_errors_total{{error_type=unknown,{_shard_labels('shard-0')}}}"
         assert collector.counters[key] == 1

--- a/tests/test_metrics_unit.py
+++ b/tests/test_metrics_unit.py
@@ -508,10 +508,18 @@ class TestConsumerGetRecordsErrors:
         consumer.client.get_records = AsyncMock(side_effect=ClientConnectionError("boom"))
         consumer.get_conn = AsyncMock()
 
-        await consumer.get_records(self._shard())
+        orig_sleep = asyncio.sleep
+
+        async def fast_sleep(_):
+            await orig_sleep(0)
+
+        with pytest.MonkeyPatch().context() as mp:
+            mp.setattr(asyncio, "sleep", fast_sleep)
+            await consumer.get_records(self._shard())
 
         key = f"consumer_errors_total{{error_type=connection,{_shard_labels('shard-0')}}}"
         assert collector.counters[key] == 1
+        consumer.get_conn.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_botocore_connection_closed_emits_connection_label(self, mock_consumer):
@@ -526,16 +534,23 @@ class TestConsumerGetRecordsErrors:
         )
         consumer.get_conn = AsyncMock()
 
-        await consumer.get_records(self._shard())
+        orig_sleep = asyncio.sleep
+
+        async def fast_sleep(_):
+            await orig_sleep(0)
+
+        with pytest.MonkeyPatch().context() as mp:
+            mp.setattr(asyncio, "sleep", fast_sleep)
+            await consumer.get_records(self._shard())
 
         key = f"consumer_errors_total{{error_type=connection,{_shard_labels('shard-0')}}}"
         assert collector.counters[key] == 1
-        # Must rebuild client, not just sleep — same remediation as ClientConnectionError
-        consumer.get_conn.assert_awaited_once()
+        consumer.get_conn.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_botocore_endpoint_connection_error_emits_connection_label(self, mock_consumer):
-        """botocore.EndpointConnectionError (DNS/TCP failure before request is sent)."""
+        """botocore.EndpointConnectionError (DNS/TCP failure before request is sent)
+        should be counted as a connection error and return without rebuilding."""
         collector = InMemoryMetricsCollector()
         consumer = mock_consumer(metrics_collector=collector)
         consumer.client = MagicMock()
@@ -544,11 +559,18 @@ class TestConsumerGetRecordsErrors:
         )
         consumer.get_conn = AsyncMock()
 
-        await consumer.get_records(self._shard())
+        orig_sleep = asyncio.sleep
+
+        async def fast_sleep(_):
+            await orig_sleep(0)
+
+        with pytest.MonkeyPatch().context() as mp:
+            mp.setattr(asyncio, "sleep", fast_sleep)
+            await consumer.get_records(self._shard())
 
         key = f"consumer_errors_total{{error_type=connection,{_shard_labels('shard-0')}}}"
         assert collector.counters[key] == 1
-        consumer.get_conn.assert_awaited_once()
+        consumer.get_conn.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_botocore_read_timeout_emits_timeout_label(self, mock_consumer):
@@ -616,6 +638,31 @@ class TestConsumerGetRecordsErrors:
             "consumer_errors_total{" f"error_type=ProvisionedThroughputExceededException,{_shard_labels('shard-0')}" "}"
         )
         assert collector.counters[key] == 1
+
+    @pytest.mark.asyncio
+    async def test_internal_failure_no_longer_rebuilds(self, mock_consumer):
+        collector = InMemoryMetricsCollector()
+        consumer = mock_consumer(metrics_collector=collector)
+        err = ClientError(
+            {"Error": {"Code": "InternalFailure", "Message": "internal failure"}},
+            "GetRecords",
+        )
+        consumer.client = MagicMock()
+        consumer.client.get_records = AsyncMock(side_effect=err)
+        consumer.get_conn = AsyncMock()
+
+        orig_sleep = asyncio.sleep
+
+        async def fast_sleep(_):
+            await orig_sleep(0)
+
+        with pytest.MonkeyPatch().context() as mp:
+            mp.setattr(asyncio, "sleep", fast_sleep)
+            await consumer.get_records(self._shard())
+
+        key = f"consumer_errors_total{{error_type=InternalFailure,{_shard_labels('shard-0')}}}"
+        assert collector.counters[key] == 1
+        consumer.get_conn.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_unknown_exception_emits_unknown_label(self, mock_consumer):


### PR DESCRIPTION
## Summary

Fixes #73.

This changes `Consumer.get_records()` so transient fetch errors no longer rebuild the shared aiobotocore client from inside shard fetch tasks.

Root cause:
rebuilding the client on one shard can close the underlying aiohttp session while other shards still have in-flight `get_records()` calls using that session. In the reported failure mode, those concurrent shard tasks can hang indefinitely, which stops record consumption even though other background activity continues.

What changed:
- removed `await self.get_conn()` from the consumer `get_records()` branches for:
  - `ClientConnectionError`
  - `ConnectionClosedError`
  - `EndpointConnectionError`
  - `ClientError` with code `InternalFailure`
- those paths now keep the existing metric emission and sleep/retry behavior instead
- kept the snapshot guard from #91 intact for the init / `wait_ready()` reconnect path

Test updates:
- updated connection-error metric tests to assert no client rebuild occurs
- added coverage for `InternalFailure` to ensure it emits the right metric label and does not call `get_conn()`

## Backwards compatibility

This changes consumer recovery behavior for transient `get_records()` failures.

Previously these paths rebuilt the shared client. After this change they leave the existing client in place and rely on the underlying aiobotocore/aiohttp connection pool to recover on subsequent requests.

This is intended as a bug fix for the 2.5.3 hang regression in concurrent consumer fetches. Public APIs and exception types are unchanged.

## Test plan

- `ENDPOINT_URL=http://localhost:4566 REDIS_HOST=localhost REDIS_PORT=16379 AWS_DEFAULT_REGION=ap-southeast-2 AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test venv/bin/python3 -m pytest -v -m "not dynamodb"`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection error handling: when connection failures occur, the consumer now pauses for 3 seconds before resuming normal operation, rather than immediately attempting to rebuild the connection. This enhances stability during transient issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->