### PR TITLE
fix(dynamodb): drop bogus Session.close() call (#94)

### DIFF
--- a/kinesis/dynamodb.py
+++ b/kinesis/dynamodb.py
@@ -404,6 +404,4 @@ class DynamoDBCheckPointer(BaseHeartbeatCheckPointer):
         """Clean up resources."""
         await super().close()
 
-        if self._session:
-            await self._session.close()
-            self._session = None
+        self._session = None

--- a/tests/test_dynamodb_checkpointer.py
+++ b/tests/test_dynamodb_checkpointer.py
@@ -48,7 +48,6 @@ class TestDynamoDBCheckPointer:
             with patch("kinesis.dynamodb.aioboto3") as mock_aioboto3:
                 # Mock session
                 mock_session = MagicMock()
-                mock_session.close = AsyncMock()
                 mock_aioboto3.Session.return_value = mock_session
 
                 # Mock DynamoDB resource


### PR DESCRIPTION
## Summary

- `aioboto3.Session` has no `close()` method, so `DynamoDBCheckPointer.close()` raised `AttributeError` on every shutdown (reported in #94).
- Resources and clients are owned by the async context managers used in every operation; the `Session` itself holds nothing to release.
- Drop the call, set `self._session = None` for parity, drop the matching test mock that was masking the bug.

## Backwards compatibility

No public API change. `close()` signature unchanged; consumers that previously hit the `AttributeError` will now exit cleanly.

## Review

External: Codex reviewed the diff, no concerns on the code change.

## Changes

```
 kinesis/dynamodb.py                 | 4 +---
 tests/test_dynamodb_checkpointer.py | 1 -
 2 files changed, 1 insertion(+), 4 deletions(-)
```

## Test plan

- [x] `pytest tests/test_dynamodb_checkpointer.py` passes (26/26)
- [x] Verified `aioboto3.Session()` has no `close` attribute against the latest pip release

Closes #94

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modified DynamoDB session cleanup behavior during application shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->