### PR TITLE
fix(consumer): handle missing NextShardIterator on exhausted shards (#26)

### DIFF
--- a/kinesis/consumer.py
+++ b/kinesis/consumer.py
@@ -6,12 +6,7 @@ from typing import Any, AsyncIterator, Dict, Optional
 
 from aiobotocore.session import AioSession
 from aiohttp import ClientConnectionError
-from botocore.exceptions import (
-    ClientError,
-    ConnectionClosedError,
-    EndpointConnectionError,
-    ReadTimeoutError,
-)
+from botocore.exceptions import ClientError, ConnectionClosedError, EndpointConnectionError, ReadTimeoutError
 
 from .base import Base
 from .checkpointers import CheckPointer, MemoryCheckPointer
@@ -315,6 +310,7 @@ class Consumer(Base):
                         continue
 
                     records = result["Records"]
+                    next_shard_iterator = result.get("NextShardIterator")
 
                     millis_behind = result.get("MillisBehindLatest")
                     if millis_behind is not None:
@@ -391,7 +387,7 @@ class Consumer(Base):
                         if last_enqueued_sequence:
                             shard["LastSequenceNumber"] = last_enqueued_sequence
 
-                            if result.get("NextShardIterator"):
+                            if next_shard_iterator:
                                 try:
                                     await asyncio.wait_for(
                                         self.queue.put(
@@ -420,10 +416,10 @@ class Consumer(Base):
                         {"stream_name": self.stream_name},
                     )
 
-                    if not result["NextShardIterator"]:
+                    if not next_shard_iterator:
                         # Shard is closed - this is normal during resharding
                         shard_id = shard["ShardId"]
-                        log.info(f"Shard {shard_id} is closed (NextShardIterator is null)")
+                        log.info(f"Shard {shard_id} is closed (NextShardIterator is null or missing)")
                         self._closed_shards.add(shard_id)
 
                         # If this is a parent shard, mark it as exhausted to allow child consumption
@@ -462,7 +458,7 @@ class Consumer(Base):
                         shard["fetch"] = None
                         continue
 
-                    shard["ShardIterator"] = result["NextShardIterator"]
+                    shard["ShardIterator"] = next_shard_iterator
 
                     shard["fetch"] = None
 

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -836,6 +836,32 @@ class TestConsumerReadySignal:
         assert consumer.is_ready, "Should be ready — all shards have iterators"
 
     @pytest.mark.asyncio
+    async def test_fetch_missing_next_shard_iterator_closes_shard(self, mock_consumer):
+        """AWS can omit NextShardIterator when an exhausted shard closes."""
+        consumer = mock_consumer(sleep_time_no_records=0.01)
+        consumer.checkpointer = MemoryCheckPointer(name="test")
+        await consumer.checkpointer.allocate("shard-0")
+
+        fetch_result = asyncio.Future()
+        fetch_result.set_result({"Records": [], "MillisBehindLatest": 0})
+        consumer.shards = [
+            {
+                "ShardId": "shard-0",
+                "ShardIterator": "iter-0",
+                "fetch": fetch_result,
+            }
+        ]
+
+        consumer.refresh_shards = AsyncMock()
+
+        await consumer.fetch()
+
+        assert "ShardIterator" not in consumer.shards[0]
+        assert consumer.shards[0]["fetch"] is None
+        assert "shard-0" in consumer._closed_shards
+        assert "shard-0" in consumer._deallocated_shards
+
+    @pytest.mark.asyncio
     async def test_fetch_max_shard_consumers(self, mock_consumer):
         """With max_shard_consumers=2, readiness fires after those 2 get iterators."""
         consumer = mock_consumer(max_shard_consumers=2)


### PR DESCRIPTION
## Summary

- Stop raising `KeyError: 'NextShardIterator'` when AWS GetRecords returns a response without the `NextShardIterator` key for an exhausted shard. The shard now closes and deallocates the same way it does when the key is `null`.
- Read `NextShardIterator` once via `result.get(...)` and reuse the local in all four branches that previously did `result["NextShardIterator"]` directly.
- Update the close-path log message from "is null" to "is null or missing" so operators can tell which signal AWS sent.

## Context

Regression of #26 (closed 2025-06-19) and #29 (closed 2022-08-16 as duplicate of #26). The 2025 reshard lifecycle work fixed topology handling but never added the defensive `.get()` on the consumer fetch path.

Re-surfaced 2026-05-04 via a maintainer dogfood soak against real AWS: 30-minute run with a 1->2->3->2->1 reshard plan against both `MemoryCheckPointer` and `DynamoDBCheckPointer` produced 9-11 `KeyError: 'NextShardIterator'` errors per run, ultimately tripping the existing fetch-error budget ("Too many fetch errors (10), stopping fetch task") and stalling the consumer.

## Review

External: Codex (uncommitted-mode review) and Gemini 2.5 Pro both cleared with no blockers. Gemini's one optional suggestion (an explicit test for the records-present-and-iterator-missing case) is noted as a follow-up; the existing close-branch path handles it correctly via the `if next_shard_iterator:` guard on the checkpoint sentinel and the terminal flush in the close branch.

## Changes

```
 kinesis/consumer.py    | 16 ++++++----------
 tests/test_consumer.py | 26 ++++++++++++++++++++++++++
 2 files changed, 32 insertions(+), 10 deletions(-)
```

## Test plan

- [x] New unit test `test_fetch_missing_next_shard_iterator_closes_shard` covers the missing-key path
- [x] `TestConsumerReadySignal` class: 11 passed (no regressions)
- [x] Full non-integration suite: 174 passed, 8 skipped, 1 pre-existing `AsyncMock` warning unrelated to this change
- [x] `pre-commit run --files kinesis/consumer.py tests/test_consumer.py` passed
- [x] Real-AWS reproduction: original symptom reproduced in dogfood soak (2026-05-04, `us-east-1`); post-fix soak under same workload returned `success=true`, `findings=[]`, `log_findings=[]`

## Backwards compatibility

No public API change. Behaviour change is strictly defensive: the consumer no longer crashes on a `GetRecords` response shape that AWS may legitimately return for an exhausted shard. Downstream consumers gain robustness; nothing they relied on is removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced shard management to robustly handle closure scenarios.

* **Tests**
  * Added test coverage for shard handling when iterator data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->